### PR TITLE
fix: resolve high-frequency musical noise and speech-boundary artifacts

### DIFF
--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -155,7 +155,7 @@ SpectralProcessorHandle spectral_denoiser_initialize(
 
   self->masking_veto = masking_veto_initialize(
       self->fft_size, self->sample_rate, CRITICAL_BANDS_TYPE_1D,
-      self->spectrum_type, false, USE_TEMPORAL_MASKING_1D_DEFAULT);
+      self->spectrum_type, true, USE_TEMPORAL_MASKING_1D_DEFAULT);
   self->suppression_engine = suppression_engine_initialize(
       self->real_spectrum_size, self->sample_rate, self->band_type,
       self->spectrum_type, true, USE_TEMPORAL_MASKING_1D_DEFAULT);

--- a/src/processors/denoiser2d/spectral_2d_denoiser.c
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.c
@@ -214,7 +214,7 @@ SpectralProcessorHandle spectral_2d_denoiser_initialize(
 
   self->masking_veto = masking_veto_initialize(
       self->fft_size, self->sample_rate, CRITICAL_BANDS_TYPE_2D,
-      self->spectrum_type, false, USE_TEMPORAL_MASKING_2D_DEFAULT);
+      self->spectrum_type, true, USE_TEMPORAL_MASKING_2D_DEFAULT);
   self->suppression_engine = suppression_engine_initialize(
       self->real_spectrum_size, self->sample_rate, CRITICAL_BANDS_TYPE_2D,
       self->spectrum_type, true, USE_TEMPORAL_MASKING_2D_DEFAULT);

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -90,6 +90,8 @@ _Static_assert(sizeof(uint32_t) == 4, "uint32_t must be exactly 32 bits");
 // Veto Parameters
 #define MASKING_VETO_SMOOTHING 0.5F  // Stabilization alpha for clean signal
 #define MASKING_VETO_NMR_RANGE 20.0F // NMR range for protection mapping (dB)
+#define MASKING_VETO_SNR_THRESHOLD                                             \
+  1.0F // 0dB SNR local bin-level threshold for full protection
 
 // Gain Estimators
 #define GSS_EXPONENT                                                           \
@@ -168,6 +170,9 @@ _Static_assert(sizeof(uint32_t) == 4, "uint32_t must be exactly 32 bits");
 #define NLM_SEARCH_RANGE_TIME_FUTURE 4U
 #define NLM_DEFAULT_H_PARAMETER 1.0F
 #define NLM_MIN_WEIGHT 1e-10F
+#define NLM_SNR_NOISE_FLOOR_MIN 1e-9F
+#define NLM_FREQ_DEPENDENT_SMOOTHING_SCALE 3.0F
+#define NLM_DISTANCE_THRESHOLD_MULTIPLIER 4.0F
 
 // Must be >= search_time_past + search_time_future + patch_size for NLM caching
 // Using power-of-two (32U) for efficient modulo wrap-around and future headroom

--- a/src/shared/denoiser_logic/processing/masking_veto.c
+++ b/src/shared/denoiser_logic/processing/masking_veto.c
@@ -252,10 +252,16 @@ void masking_veto_apply(MaskingVeto* self, const float* smoothed_spectrum,
       bin_protection = self->band_audibility[num_bands - 1];
     }
 
-    // Lerp alpha toward 1.0 (no extra subtraction) based on protection.
-    // At full protection (depth=1.0, protection=1.0): alpha -> 1.0
-    // At zero protection: alpha unchanged
-    const float veto_amount = bin_protection * depth;
+    const float bin_clean = self->clean_signal_estimation[k];
+    const float bin_noise = noise_spectrum[k];
+    const float bin_snr = bin_clean / (bin_noise + SPECTRAL_EPSILON);
+    const float bin_snr_scale =
+        fminf(bin_snr / MASKING_VETO_SNR_THRESHOLD, 1.0F);
+
+    // Lerp alpha toward 1.0 (no extra subtraction) based on protection and bin
+    // SNR. At full protection (depth=1.0, protection=1.0): alpha -> 1.0 At zero
+    // protection: alpha unchanged
+    const float veto_amount = bin_protection * bin_snr_scale * depth;
     alpha[k] = alpha[k] + ((1.0F - alpha[k]) * veto_amount);
   }
 }

--- a/src/shared/denoiser_logic/processing/nlm_filter.c
+++ b/src/shared/denoiser_logic/processing/nlm_filter.c
@@ -286,9 +286,6 @@ bool nlm_filter_process_generic(NlmFilter* filter, float* smoothed_snr) {
   float* weight_sum = filter->weight_accum;
   memset(weight_sum, 0, spectrum_size * sizeof(float));
 
-  const float current_inv_h2 = filter->inv_h_squared;
-  const float current_dist_threshold = filter->distance_threshold_actual;
-
 #if SB_HAS_OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(filter->num_threads)
 #endif
@@ -311,6 +308,24 @@ bool nlm_filter_process_generic(NlmFilter* filter, float* smoothed_snr) {
     }
     if (target_snr_sum < 1e-6F) {
       continue;
+    }
+
+    float current_inv_h2 = filter->inv_h_squared;
+    float current_dist_threshold = filter->distance_threshold_actual;
+
+    if (spectrum_size > 1) {
+      float normalized_freq = (float)block_center / (float)(spectrum_size - 1);
+      float freq_scale = 1.0F + NLM_FREQ_DEPENDENT_SMOOTHING_SCALE *
+                                    normalized_freq * normalized_freq;
+      float h_val = filter->config.h_parameter * freq_scale;
+      float h_squared = h_val * h_val;
+      current_inv_h2 = 1.0F / h_squared;
+      if (filter->config.distance_threshold <= 0.0F) {
+        current_dist_threshold = NLM_DISTANCE_THRESHOLD_MULTIPLIER * h_squared;
+      } else {
+        current_dist_threshold =
+            filter->config.distance_threshold * freq_scale * freq_scale;
+      }
     }
 
     sb_vec8_t target_vecs[8];
@@ -445,20 +460,20 @@ void nlm_filter_calculate_snr(NlmFilter* filter,
   const uint32_t spectrum_size = filter->config.spectrum_size;
   uint32_t k = 0;
 
-  sb_vec8_t eps = sb_set8(SPECTRAL_EPSILON);
-  sb_vec8_t flt_min = sb_set8(FLT_MIN);
+  sb_vec8_t noise_floor_min = sb_set8(NLM_SNR_NOISE_FLOOR_MIN);
 
   for (; k + 7 < spectrum_size; k += 8) {
     sb_vec8_t noise = sb_load8(noise_spectrum + k);
-    sb_vec8_t mask = sb_gt8(noise, flt_min);
-    sb_vec8_t denom = sb_sel8(mask, noise, eps);
+    sb_vec8_t mask = sb_gt8(noise, noise_floor_min);
+    sb_vec8_t denom = sb_sel8(mask, noise, noise_floor_min);
     sb_vec8_t snr = sb_div8(sb_load8(reference_spectrum + k), denom);
     sb_store8(snr_frame + k, snr);
   }
 
   for (; k < spectrum_size; k++) {
-    float denom =
-        noise_spectrum[k] > FLT_MIN ? noise_spectrum[k] : SPECTRAL_EPSILON;
+    float denom = noise_spectrum[k] > NLM_SNR_NOISE_FLOOR_MIN
+                      ? noise_spectrum[k]
+                      : NLM_SNR_NOISE_FLOOR_MIN;
     snr_frame[k] = reference_spectrum[k] / denom;
   }
 }
@@ -474,20 +489,20 @@ void nlm_filter_reconstruct_magnitude(NlmFilter* filter,
   const uint32_t spectrum_size = filter->config.spectrum_size;
   uint32_t k = 0;
 
-  sb_vec8_t eps = sb_set8(SPECTRAL_EPSILON);
-  sb_vec8_t flt_min = sb_set8(FLT_MIN);
+  sb_vec8_t noise_floor_min = sb_set8(NLM_SNR_NOISE_FLOOR_MIN);
 
   for (; k + 7 < spectrum_size; k += 8) {
     sb_vec8_t noise = sb_load8(noise_spectrum + k);
-    sb_vec8_t mask = sb_gt8(noise, flt_min);
-    sb_vec8_t denom = sb_sel8(mask, noise, eps);
+    sb_vec8_t mask = sb_gt8(noise, noise_floor_min);
+    sb_vec8_t denom = sb_sel8(mask, noise, noise_floor_min);
     sb_vec8_t mag = sb_mul8(sb_load8(smoothed_snr + k), denom);
     sb_store8(magnitude_spectrum + k, mag);
   }
 
   for (; k < spectrum_size; k++) {
-    float denom =
-        noise_spectrum[k] > FLT_MIN ? noise_spectrum[k] : SPECTRAL_EPSILON;
+    float denom = noise_spectrum[k] > NLM_SNR_NOISE_FLOOR_MIN
+                      ? noise_spectrum[k]
+                      : NLM_SNR_NOISE_FLOOR_MIN;
     magnitude_spectrum[k] = smoothed_snr[k] * denom;
   }
 }

--- a/src/shared/denoiser_logic/processing/nlm_filter_avx.c
+++ b/src/shared/denoiser_logic/processing/nlm_filter_avx.c
@@ -104,9 +104,6 @@ bool nlm_filter_process_avx(NlmFilter* filter, float* smoothed_snr) {
   float* weight_sum = filter->weight_accum;
   memset(weight_sum, 0, spectrum_size * sizeof(float));
 
-  const float current_inv_h2 = filter->inv_h_squared;
-  const float current_dist_threshold = filter->distance_threshold_actual;
-
 #if SB_HAS_OPENMP
 #pragma omp parallel for schedule(dynamic) num_threads(filter->num_threads)
 #endif
@@ -129,6 +126,24 @@ bool nlm_filter_process_avx(NlmFilter* filter, float* smoothed_snr) {
     }
     if (target_snr_sum < 1e-6F) {
       continue;
+    }
+
+    float current_inv_h2 = filter->inv_h_squared;
+    float current_dist_threshold = filter->distance_threshold_actual;
+
+    if (spectrum_size > 1) {
+      float normalized_freq = (float)block_center / (float)(spectrum_size - 1);
+      float freq_scale = 1.0F + NLM_FREQ_DEPENDENT_SMOOTHING_SCALE *
+                                    normalized_freq * normalized_freq;
+      float h_val = filter->config.h_parameter * freq_scale;
+      float h_squared = h_val * h_val;
+      current_inv_h2 = 1.0F / h_squared;
+      if (filter->config.distance_threshold <= 0.0F) {
+        current_dist_threshold = NLM_DISTANCE_THRESHOLD_MULTIPLIER * h_squared;
+      } else {
+        current_dist_threshold =
+            filter->config.distance_threshold * freq_scale * freq_scale;
+      }
     }
 
     sb_vec8_t target_vecs[8];

--- a/src/shared/utils/absolute_hearing_thresholds.c
+++ b/src/shared/utils/absolute_hearing_thresholds.c
@@ -147,8 +147,12 @@ bool apply_thresholds_as_floor(AbsoluteHearingThresholds* self,
   for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
     const float spl_level = (10.F * log10f(spectrum[k] + SPECTRAL_EPSILON)) +
                             self->spl_reference_value;
-    spectrum[k] =
-        powf(10.F, fmaxf(spl_level, self->absolute_thresholds[k]) / 10.F);
+    const float max_spl = fmaxf(spl_level, self->absolute_thresholds[k]);
+    spectrum[k] = powf(10.F, (max_spl - self->spl_reference_value) / 10.F) -
+                  SPECTRAL_EPSILON;
+    if (spectrum[k] < 0.0F) {
+      spectrum[k] = 0.0F;
+    }
   }
 
   return true;

--- a/tests/test_shared_utils.c
+++ b/tests/test_shared_utils.c
@@ -38,7 +38,7 @@ void test_absolute_hearing_thresholds(void) {
 
   float spectrum[513] = {0.0f}; // 513 = fft_size/2 + 1
   for (int i = 0; i < 513; i++) {
-    spectrum[i] = 0.001f; // Set low values that should be floored
+    spectrum[i] = 0.0f; // Set low values that should be floored
   }
 
   TEST_ASSERT(apply_thresholds_as_floor(aht, spectrum),
@@ -47,7 +47,7 @@ void test_absolute_hearing_thresholds(void) {
   // Check that some values were floored to hearing thresholds
   bool some_values_changed = false;
   for (int i = 0; i < 513; i++) {
-    if (spectrum[i] > 0.001f) {
+    if (spectrum[i] > 0.0f) {
       some_values_changed = true;
       break;
     }


### PR DESCRIPTION
This PR addresses high-frequency musical noise (speckling/clustering) and speech-boundary "noise halos" by implementing two major DSP enhancements:

1. **Bin-Level Masking Protection**: SNR-dependent psychoacoustic veto scaling is migrated from Bark band level to individual frequency bins in `masking_veto.c` with a local bin threshold of 0dB SNR. This prevents speech activity in adjacent bins from incorrectly protecting quiet noise-only bins (eliminating halos), while preserving formants. It also prevents the masking veto from degrading tonal noise reduction at nearby frequencies.
2. **Frequency-Dependent NLM Smoothing**: The NLM decay parameter $h$ is dynamically scaled quadratically with the normalized bin frequency position in `nlm_filter.c` and `nlm_filter_avx.c`. This applies heavy linear-like averaging at high frequencies to wash out speckling/rare-patch artifacts, while maintaining crisp edge preservation for speech formants in the low/mid frequencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected absolute hearing threshold floor computation logic.

* **Improvements**
  * Denoising now includes SNR-adaptive masking adjustment per frequency bin.
  * Filter processing now uses frequency-dependent parameter scaling.
  * Added SIMD optimization support for faster processing.

* **New Features**
  * Added configurable parameters: SNR thresholds and NLM algorithm settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lucianodato/libspecbleach/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->