### PR TITLE
cleanup: ponytail audit simplifications

### DIFF
--- a/src/shared/denoiser_logic/processing/spectral_whitening.c
+++ b/src/shared/denoiser_logic/processing/spectral_whitening.c
@@ -32,7 +32,6 @@ static int float_comparator(const void* a, const void* b) {
 }
 
 struct SpectralWhitening {
-  float* tapering_window;
   uint32_t fft_size;
   uint32_t real_spectrum_size;
 };
@@ -47,27 +46,12 @@ SpectralWhitening* spectral_whitening_initialize(const uint32_t fft_size) {
   self->fft_size = fft_size;
   self->real_spectrum_size = (self->fft_size / 2U) + 1U;
 
-  self->tapering_window =
-      (float*)calloc(self->real_spectrum_size, sizeof(float));
-  if (!self->tapering_window) {
-    free(self);
-    return NULL;
-  }
-
-  // Tapering is disabled to allow true 100% flat whitening across the spectrum.
-  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
-    self->tapering_window[k] = 1.0f;
-  }
-
   return self;
 }
 
 void spectral_whitening_free(SpectralWhitening* self) {
   if (!self) {
     return;
-  }
-  if (self->tapering_window) {
-    free(self->tapering_window);
   }
   free(self);
 }
@@ -120,8 +104,7 @@ void spectral_whitening_get_weights(SpectralWhitening* self,
       // This results in weights >= 1.0 for valleys and <= 1.0 for spikes
       weight = powf(anchor_magnitude / smoothed_profile[k], normalized_factor);
     }
-    // Weights include unity-tapering (for now)
-    weights_out[k] = weight * self->tapering_window[k];
+    weights_out[k] = weight;
   }
 
   free(smoothed_profile);

--- a/src/shared/utils/critical_bands.c
+++ b/src/shared/utils/critical_bands.c
@@ -31,13 +31,6 @@ static const float opus_bands[20] = {200.F,  400.F,  600.F,  800.F,   1000.F,
                                      1200.F, 1400.F, 1600.F, 2000.F,  2400.F,
                                      2800.F, 3200.F, 4000.F, 4800.F,  5600.F,
                                      6800.F, 8000.F, 9600.F, 12000.F, 15600.F};
-static const float mel_bands[33] = {
-    250.F,  500.F,  750.F,  1000.F, 1250.F, 1500.F, 1750.F, 2000.F,
-    2250.F, 2500.F, 2750.F, 3000.F, 3250.F, 3500.F, 3750.F, 4000.F,
-    4250.F, 4500.F, 4750.F, 5000.F, 5250.F, 5500.F, 5750.F, 6000.F,
-    6250.F, 6500.F, 6750.F, 7000.F, 7250.F, 7500.F, 7750.F, 8000.F};
-static const float octave_bands[10] = {31.5F,  63.F,   125.F,  250.F,  500.F,
-                                       1000.F, 2000.F, 4000.F, 8000.F, 16000.F};
 
 void set_number_of_bands(CriticalBands* self);
 static void compute_mapping_spectrum(CriticalBands* self);
@@ -131,25 +124,11 @@ static void compute_mapping_spectrum(CriticalBands* self) {
           get_last_valid_band_for_samplerate(self, number_of_bark_bands);
       break;
     }
-    case MEL_SCALE: {
-      self->current_critical_bands = (float*)mel_bands;
-      uint32_t number_of_mel_bands = sizeof(mel_bands) / sizeof(float);
-      self->number_bands =
-          get_last_valid_band_for_samplerate(self, number_of_mel_bands);
-      break;
-    }
     case OPUS_SCALE: {
       self->current_critical_bands = (float*)opus_bands;
       uint32_t number_of_opus_bands = sizeof(opus_bands) / sizeof(float);
       self->number_bands =
           get_last_valid_band_for_samplerate(self, number_of_opus_bands);
-      break;
-    }
-    case OCTAVE_SCALE: {
-      self->current_critical_bands = (float*)octave_bands;
-      uint32_t number_of_octave_bands = sizeof(octave_bands) / sizeof(float);
-      self->number_bands =
-          get_last_valid_band_for_samplerate(self, number_of_octave_bands);
       break;
     }
     default:

--- a/src/shared/utils/critical_bands.h
+++ b/src/shared/utils/critical_bands.h
@@ -28,9 +28,7 @@ typedef struct CriticalBands CriticalBands;
 
 typedef enum CriticalBandType {
   BARK_SCALE = 0,
-  MEL_SCALE = 1,
-  OPUS_SCALE = 2,
-  OCTAVE_SCALE = 3,
+  OPUS_SCALE = 1,
 } CriticalBandType;
 
 typedef struct CriticalBandIndexes {

--- a/src/shared/utils/general_utils.c
+++ b/src/shared/utils/general_utils.c
@@ -39,16 +39,19 @@ float remap_percentage_log_like_unity(const float value) {
 }
 
 int get_next_divisible_two(int number) {
-  int q = number / 2;
-  int n1 = 2 * q;
-  int n2 = (number * 2) > 0 ? (2 * (q + 1)) : (2 * (q - 1));
-  if (abs(number - n1) < abs(number - n2)) {
-    return n1;
-  }
-
-  return n2;
+  return number + (number & 1);
 }
 
 int get_next_power_two(int number) {
-  return (int)roundf(powf(2.F, ceilf(log2f((float)number))));
+  if (number <= 0) {
+    return 1;
+  }
+  number--;
+  number |= number >> 1;
+  number |= number >> 2;
+  number |= number >> 4;
+  number |= number >> 8;
+  number |= number >> 16;
+  number++;
+  return number;
 }

--- a/src/shared/utils/spectral_utils.c
+++ b/src/shared/utils/spectral_utils.c
@@ -87,32 +87,6 @@ bool initialize_spectrum_with_value(float* spectrum, uint32_t spectrum_size,
   return true;
 }
 
-float max_spectral_value(const float* spectrum,
-                         const uint32_t real_spectrum_size) {
-  if (!spectrum || real_spectrum_size == 0U) {
-    return 0.F;
-  }
-
-  float max = spectrum[0];
-  for (uint32_t k = 1U; k < real_spectrum_size; k++) {
-    max = fmaxf(spectrum[k], max);
-  }
-  return max;
-}
-
-float min_spectral_value(const float* spectrum,
-                         const uint32_t real_spectrum_size) {
-  if (!spectrum || real_spectrum_size == 0U) {
-    return 0.F;
-  }
-
-  float min = spectrum[0];
-  for (uint32_t k = 1U; k < real_spectrum_size; k++) {
-    min = fminf(spectrum[k], min);
-  }
-  return min;
-}
-
 bool min_spectrum_float(float* spectrum_one, const float* spectrum_two,
                         const uint32_t spectrum_size) {
   if (!spectrum_one || !spectrum_two || spectrum_size == 0U) {
@@ -139,51 +113,6 @@ bool max_spectrum_float(float* spectrum_one, const float* spectrum_two,
   return true;
 }
 
-bool min_spectrum_double(double* spectrum_one, const double* spectrum_two,
-                         const uint32_t spectrum_size) {
-  if (!spectrum_one || !spectrum_two || spectrum_size == 0U) {
-    return false;
-  }
-
-  for (uint32_t k = 0; k < spectrum_size; k++) {
-    spectrum_one[k] = fmin(spectrum_one[k], spectrum_two[k]);
-  }
-
-  return true;
-}
-
-bool max_spectrum_double(double* spectrum_one, const double* spectrum_two,
-                         const uint32_t spectrum_size) {
-  if (!spectrum_one || !spectrum_two || spectrum_size == 0U) {
-    return false;
-  }
-
-  for (uint32_t k = 0; k < spectrum_size; k++) {
-    spectrum_one[k] = fmax(spectrum_one[k], spectrum_two[k]);
-  }
-
-  return true;
-}
-
-bool direct_matrix_to_vector_spectral_convolution(const float* matrix_spectum,
-                                                  const float* spectrum,
-                                                  float* out_spectrum,
-                                                  uint32_t spectrum_size) {
-  if (!matrix_spectum || !spectrum || !out_spectrum || spectrum_size == 0U) {
-    return false;
-  }
-
-  for (uint32_t i = 0U; i < spectrum_size; i++) {
-    out_spectrum[i] = 0.F;
-    for (uint32_t j = 0U; j < spectrum_size; j++) {
-      out_spectrum[i] +=
-          (matrix_spectum[(i * spectrum_size) + j] * spectrum[j]);
-    }
-  }
-
-  return true;
-}
-
 float fft_bin_to_freq(const uint32_t bin_index, const uint32_t sample_rate,
                       const uint32_t fft_size) {
   return (float)bin_index * ((float)sample_rate / (float)fft_size);
@@ -192,21 +121,6 @@ float fft_bin_to_freq(const uint32_t bin_index, const uint32_t sample_rate,
 uint32_t freq_to_fft_bin(const float freq, const uint32_t sample_rate,
                          const uint32_t fft_size) {
   return (uint32_t)((freq / ((float)sample_rate / (float)fft_size)) + 0.5f);
-}
-
-float spectral_flux(const float* spectrum, const float* previous_spectrum,
-                    const uint32_t spectrum_size) {
-  if (!spectrum || !previous_spectrum || spectrum_size == 0U) {
-    return 0.F;
-  }
-
-  float spectral_flux = 0.F;
-
-  for (uint32_t i = 0U; i < spectrum_size; i++) {
-    const float temp = sqrtf(spectrum[i]) - sqrtf(previous_spectrum[i]);
-    spectral_flux += (temp + fabsf(temp)) / 2.F;
-  }
-  return spectral_flux;
 }
 
 bool get_rolling_mean_spectrum(float* averaged_spectrum,

--- a/src/shared/utils/spectral_utils.h
+++ b/src/shared/utils/spectral_utils.h
@@ -34,38 +34,16 @@ typedef enum WindowTypes {
 bool get_fft_window(float* window, uint32_t fft_size, WindowTypes window_type);
 bool initialize_spectrum_with_value(float* spectrum, uint32_t spectrum_size,
                                     float value);
-bool direct_matrix_to_vector_spectral_convolution(const float* matrix_spectum,
-                                                  const float* spectrum,
-                                                  float* out_spectrum,
-                                                  uint32_t spectrum_size);
-float max_spectral_value(const float* spectrum, uint32_t real_spectrum_size);
-float min_spectral_value(const float* spectrum, uint32_t real_spectrum_size);
-
-#define min_spectrum(spectrum_one, spectrum_two, spectrum_size)                \
-  _Generic((spectrum_one),                                                     \
-      float*: min_spectrum_float,                                              \
-      double*: min_spectrum_double,                                            \
-      default: min_spectrum_float)(spectrum_one, spectrum_two, spectrum_size)
-
-#define max_spectrum(spectrum_one, spectrum_two, spectrum_size)                \
-  _Generic((spectrum_one),                                                     \
-      float*: max_spectrum_float,                                              \
-      double*: max_spectrum_double,                                            \
-      default: max_spectrum_float)(spectrum_one, spectrum_two, spectrum_size)
+#define min_spectrum min_spectrum_float
+#define max_spectrum max_spectrum_float
 
 bool min_spectrum_float(float* spectrum_one, const float* spectrum_two,
                         uint32_t spectrum_size);
 bool max_spectrum_float(float* spectrum_one, const float* spectrum_two,
                         uint32_t spectrum_size);
-bool min_spectrum_double(double* spectrum_one, const double* spectrum_two,
-                         uint32_t spectrum_size);
-bool max_spectrum_double(double* spectrum_one, const double* spectrum_two,
-                         uint32_t spectrum_size);
 float fft_bin_to_freq(uint32_t bin_index, uint32_t sample_rate,
                       uint32_t fft_size);
 uint32_t freq_to_fft_bin(float freq, uint32_t sample_rate, uint32_t fft_size);
-float spectral_flux(const float* spectrum, const float* previous_spectrum,
-                    uint32_t spectrum_size);
 bool get_rolling_mean_spectrum(float* averaged_spectrum,
                                const float* current_spectrum,
                                uint32_t number_of_blocks,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -95,6 +95,16 @@ test_shared_utils = executable('test_shared_utils',
   include_directories: [inc, src_inc]
 )
 
+# Spectral Utils tests
+test_spectral_utils = executable('test_spectral_utils',
+  sources: ['test_spectral_utils.c'],
+  dependencies: [libspecbleach_dep, m_dep],
+  c_args: test_c_args,
+  link_args: test_link_args,
+  include_directories: [inc, src_inc]
+)
+
+
 
 # Noise profile tests
 test_noise_profile = executable('test_noise_profile',
@@ -199,6 +209,7 @@ if sndfile_dep.found()
 endif
 test('gain_calculator', test_gain_calculator)
 test('shared_utils', test_shared_utils)
+test('spectral_utils', test_spectral_utils)
 test('noise_profile', test_noise_profile)
 test('specbleach_denoiser', test_specbleach_denoiser)
 test('specbleach_2d_denoiser', test_specbleach_2d_denoiser)

--- a/tests/test_spectral_utils.c
+++ b/tests/test_spectral_utils.c
@@ -1,0 +1,373 @@
+/*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "shared/utils/spectral_utils.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define TEST_ASSERT(condition, message)                                        \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      fprintf(stderr, "TEST FAILED: %s\n", message);                           \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define TEST_FLOAT_CLOSE(a, b, tolerance)                                      \
+  TEST_ASSERT(fabsf((a) - (b)) < (tolerance), "Float values not close enough")
+
+void test_get_fft_window(void) {
+  printf("Testing get_fft_window...\n");
+
+  uint32_t fft_size = 64;
+  float window[64];
+
+  // Test NULL and size 0 checks
+  TEST_ASSERT(!get_fft_window(NULL, fft_size, HANN_WINDOW),
+              "NULL window check");
+  TEST_ASSERT(!get_fft_window(window, 0, HANN_WINDOW), "Size 0 check");
+
+  // Test Hann
+  TEST_ASSERT(get_fft_window(window, fft_size, HANN_WINDOW), "HANN Window");
+  TEST_FLOAT_CLOSE(window[0], 0.0f, 1e-6f);
+  TEST_ASSERT(window[fft_size / 2] > 0.9f, "Hann middle check");
+
+  // Test Hamming
+  TEST_ASSERT(get_fft_window(window, fft_size, HAMMING_WINDOW),
+              "HAMMING Window");
+  TEST_ASSERT(window[0] > 0.07f && window[0] < 0.09f, "Hamming endpoint check");
+
+  // Test Blackman
+  TEST_ASSERT(get_fft_window(window, fft_size, BLACKMAN_WINDOW),
+              "BLACKMAN Window");
+  TEST_FLOAT_CLOSE(window[0], 0.0f, 1e-6f);
+
+  // Test Vorbis
+  TEST_ASSERT(get_fft_window(window, fft_size, VORBIS_WINDOW), "VORBIS Window");
+  TEST_FLOAT_CLOSE(window[0], 0.0f, 1e-6f);
+
+  // Test default window type (no-op loop but returns true)
+  TEST_ASSERT(get_fft_window(window, fft_size, (WindowTypes)99),
+              "Invalid window type check");
+
+  printf("✓ get_fft_window tests passed\n");
+}
+
+void test_initialize_spectrum_with_value(void) {
+  printf("Testing initialize_spectrum_with_value...\n");
+
+  uint32_t size = 10;
+  float spectrum[10];
+
+  // Test NULL and size 0 checks
+  TEST_ASSERT(!initialize_spectrum_with_value(NULL, size, 2.5f),
+              "NULL spectrum check");
+  TEST_ASSERT(!initialize_spectrum_with_value(spectrum, 0, 2.5f),
+              "Size 0 check");
+
+  // Test valid initialization
+  TEST_ASSERT(initialize_spectrum_with_value(spectrum, size, 2.5f),
+              "Init spectrum");
+  for (uint32_t i = 0; i < size; i++) {
+    TEST_FLOAT_CLOSE(spectrum[i], 2.5f, 1e-6f);
+  }
+
+  printf("✓ initialize_spectrum_with_value tests passed\n");
+}
+
+void test_min_max_spectrum_float(void) {
+  printf("Testing min_spectrum_float and max_spectrum_float...\n");
+
+  uint32_t size = 4;
+  float s1[] = {1.0f, 10.0f, 5.0f, 2.0f};
+  float s2[] = {2.0f, 5.0f, 5.0f, 1.0f};
+
+  // Test NULL and size 0 checks for min_spectrum_float
+  TEST_ASSERT(!min_spectrum_float(NULL, s2, size), "min_spectrum NULL 1");
+  TEST_ASSERT(!min_spectrum_float(s1, NULL, size), "min_spectrum NULL 2");
+  TEST_ASSERT(!min_spectrum_float(s1, s2, 0), "min_spectrum size 0");
+
+  // Test NULL and size 0 checks for max_spectrum_float
+  TEST_ASSERT(!max_spectrum_float(NULL, s2, size), "max_spectrum NULL 1");
+  TEST_ASSERT(!max_spectrum_float(s1, NULL, size), "max_spectrum NULL 2");
+  TEST_ASSERT(!max_spectrum_float(s1, s2, 0), "max_spectrum size 0");
+
+  // Test operations
+  float s1_min[] = {1.0f, 10.0f, 5.0f, 2.0f};
+  TEST_ASSERT(min_spectrum_float(s1_min, s2, size), "min_spectrum execution");
+  TEST_FLOAT_CLOSE(s1_min[0], 1.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(s1_min[1], 5.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(s1_min[2], 5.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(s1_min[3], 1.0f, 1e-6f);
+
+  float s1_max[] = {1.0f, 10.0f, 5.0f, 2.0f};
+  TEST_ASSERT(max_spectrum_float(s1_max, s2, size), "max_spectrum execution");
+  TEST_FLOAT_CLOSE(s1_max[0], 2.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(s1_max[1], 10.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(s1_max[2], 5.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(s1_max[3], 2.0f, 1e-6f);
+
+  printf("✓ min/max spectrum float tests passed\n");
+}
+
+void test_fft_frequency_conversions(void) {
+  printf("Testing fft_bin_to_freq and freq_to_fft_bin...\n");
+
+  uint32_t sr = 44100;
+  uint32_t fft_size = 1024;
+
+  // DC bin
+  TEST_FLOAT_CLOSE(fft_bin_to_freq(0, sr, fft_size), 0.0f, 1e-6f);
+  TEST_ASSERT(freq_to_fft_bin(0.0f, sr, fft_size) == 0, "DC frequency check");
+
+  // Nyquist bin
+  float nyquist_freq = (float)sr / 2.0f;
+  TEST_FLOAT_CLOSE(fft_bin_to_freq(512, sr, fft_size), nyquist_freq, 1e-6f);
+  TEST_ASSERT(freq_to_fft_bin(nyquist_freq, sr, fft_size) == 512,
+              "Nyquist check");
+
+  printf("✓ fft frequency conversion tests passed\n");
+}
+
+void test_get_rolling_mean_spectrum(void) {
+  printf("Testing get_rolling_mean_spectrum...\n");
+
+  uint32_t size = 4;
+  float current[] = {1.0f, 2.0f, 3.0f, 4.0f};
+  float avg[4] = {0.0f};
+
+  // Test NULL and size 0 checks
+  TEST_ASSERT(!get_rolling_mean_spectrum(NULL, current, 1, size),
+              "rolling_mean NULL avg");
+  TEST_ASSERT(!get_rolling_mean_spectrum(avg, NULL, 1, size),
+              "rolling_mean NULL current");
+  TEST_ASSERT(!get_rolling_mean_spectrum(avg, current, 1, 0),
+              "rolling_mean size 0");
+
+  // Test blocks == 1 (should just copy)
+  TEST_ASSERT(get_rolling_mean_spectrum(avg, current, 1, size),
+              "rolling_mean blocks=1");
+  for (uint32_t i = 0; i < size; i++) {
+    TEST_FLOAT_CLOSE(avg[i], current[i], 1e-6f);
+  }
+
+  // Test blocks > 1
+  float current2[] = {3.0f, 4.0f, 5.0f, 6.0f};
+  TEST_ASSERT(get_rolling_mean_spectrum(avg, current2, 2, size),
+              "rolling_mean blocks=2");
+  // avg = avg + (current2 - avg) / 2 = 1 + (3-1)/2 = 2, etc.
+  TEST_FLOAT_CLOSE(avg[0], 2.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(avg[1], 3.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(avg[2], 4.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(avg[3], 5.0f, 1e-6f);
+
+  printf("✓ get_rolling_mean_spectrum tests passed\n");
+}
+
+void test_get_rolling_median_spectrum(void) {
+  printf("Testing get_rolling_median_spectrum...\n");
+
+  uint32_t size = 3;
+  float frame1[] = {1.0f, 10.0f, 5.0f};
+  float frame2[] = {3.0f, 2.0f, 8.0f};
+  float frame3[] = {2.0f, 5.0f, 1.0f};
+  const float* history3[] = {frame1, frame2, frame3};
+
+  float median[3] = {0.0f};
+
+  // Test NULL and size 0 checks
+  TEST_ASSERT(!get_rolling_median_spectrum(NULL, history3, 3, size),
+              "rolling_median NULL output");
+  TEST_ASSERT(!get_rolling_median_spectrum(median, NULL, 3, size),
+              "rolling_median NULL history");
+  TEST_ASSERT(!get_rolling_median_spectrum(median, history3, 3, 0),
+              "rolling_median size 0");
+
+  // Odd number of blocks (3)
+  // Sorted inputs for bin 0: 1.0, 2.0, 3.0 -> median is 2.0
+  // Sorted inputs for bin 1: 2.0, 5.0, 10.0 -> median is 5.0
+  // Sorted inputs for bin 2: 1.0, 5.0, 8.0 -> median is 5.0
+  TEST_ASSERT(get_rolling_median_spectrum(median, history3, 3, size),
+              "rolling_median blocks=3");
+  TEST_FLOAT_CLOSE(median[0], 2.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(median[1], 5.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(median[2], 5.0f, 1e-6f);
+
+  // Even number of blocks (2)
+  const float* history2[] = {frame1, frame2};
+  // Sorted inputs for bin 0: 1.0, 3.0 -> median is 2.0
+  // Sorted inputs for bin 1: 2.0, 10.0 -> median is 6.0
+  // Sorted inputs for bin 2: 5.0, 8.0 -> median is 6.5
+  TEST_ASSERT(get_rolling_median_spectrum(median, history2, 2, size),
+              "rolling_median blocks=2");
+  TEST_FLOAT_CLOSE(median[0], 2.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(median[1], 6.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(median[2], 6.5f, 1e-6f);
+
+  // Test NULL pointer in history fallback to 0.0f
+  const float* history_null[] = {frame1, NULL, frame3};
+  // Sorted inputs for bin 0: 0.0 (fallback), 1.0, 2.0 -> median is 1.0
+  TEST_ASSERT(get_rolling_median_spectrum(median, history_null, 3, size),
+              "rolling_median with NULL history element");
+  TEST_FLOAT_CLOSE(median[0], 1.0f, 1e-6f);
+
+  printf("✓ get_rolling_median_spectrum tests passed\n");
+}
+
+void test_smooth_spectrum(void) {
+  printf("Testing smooth_spectrum...\n");
+
+  float spec[] = {1.0f, 2.0f, 4.0f, 8.0f};
+  uint32_t size = 4;
+
+  // NULL check
+  smooth_spectrum(NULL, size, 0.5f); // Should not crash
+
+  // Size < 2 check
+  float single_spec[] = {1.0f};
+  smooth_spectrum(single_spec, 1, 0.5f);
+  TEST_FLOAT_CLOSE(single_spec[0], 1.0f, 1e-6f);
+
+  // Smoothing factor <= 0.0f check
+  float spec_no_change[] = {1.0f, 2.0f, 4.0f, 8.0f};
+  smooth_spectrum(spec_no_change, size, 0.0f);
+  for (uint32_t i = 0; i < size; i++) {
+    TEST_FLOAT_CLOSE(spec_no_change[i], spec[i], 1e-6f);
+  }
+
+  // Normal smoothing execution
+  smooth_spectrum(spec, size, 0.5f);
+
+  // Expected values calculation:
+  // bin 0: avg(1.0, 2.0)*0.5 + 1.0*0.5 = 1.5*0.5 + 0.5 = 1.25
+  // bin 1: avg(1.0, 2.0, 4.0)*0.5 + 2.0*0.5 = 2.3333*0.5 + 1.0 = 2.16667
+  // bin 2: avg(2.0, 4.0, 8.0)*0.5 + 4.0*0.5 = 4.6667*0.5 + 2.0 = 4.33333
+  // bin 3: avg(4.0, 8.0)*0.5 + 8.0*0.5 = 6.0*0.5 + 4.0 = 7.0
+  TEST_FLOAT_CLOSE(spec[0], 1.25f, 1e-5f);
+  TEST_FLOAT_CLOSE(spec[1], 2.16667f, 1e-5f);
+  TEST_FLOAT_CLOSE(spec[2], 4.33333f, 1e-5f);
+  TEST_FLOAT_CLOSE(spec[3], 7.00000f, 1e-5f);
+
+  printf("✓ smooth_spectrum tests passed\n");
+}
+
+void test_interpolate_spectrum_gaps(void) {
+  printf("Testing interpolate_spectrum_gaps...\n");
+
+  float threshold = 0.1f;
+
+  // NULL and size < 3 checks
+  interpolate_spectrum_gaps(NULL, 10, threshold); // Should not crash
+  float short_spec[] = {0.05f, 0.5f};
+  interpolate_spectrum_gaps(short_spec, 2, threshold);
+  TEST_FLOAT_CLOSE(short_spec[0], 0.05f, 1e-6f);
+
+  // No gaps
+  float no_gaps[] = {0.5f, 0.6f, 0.7f, 0.8f};
+  interpolate_spectrum_gaps(no_gaps, 4, threshold);
+  TEST_FLOAT_CLOSE(no_gaps[1], 0.6f, 1e-6f);
+
+  // Gap in the middle (interpolated)
+  float spec[] = {1.0f, 0.05f, 3.0f}; // Gap at index 1
+  interpolate_spectrum_gaps(spec, 3, threshold);
+  // Interpolated: start_val = spec[0] = 1.0, end_val = spec[2] = 3.0.
+  // step = (3.0 - 1.0) / (2 - 0) = 1.0
+  // spec[1] = 1.0 + 1.0 * (1 - 0) = 2.0
+  TEST_FLOAT_CLOSE(spec[1], 2.0f, 1e-6f);
+
+  // Gap extending to the end (should not be interpolated)
+  float spec_end[] = {1.0f, 0.05f, 0.05f}; // Gaps at 1 and 2
+  interpolate_spectrum_gaps(spec_end, 3, threshold);
+  TEST_FLOAT_CLOSE(spec_end[1], 0.05f, 1e-6f);
+  TEST_FLOAT_CLOSE(spec_end[2], 0.05f, 1e-6f);
+
+  printf("✓ interpolate_spectrum_gaps tests passed\n");
+}
+
+void test_get_morphed_profile(void) {
+  printf("Testing get_morphed_profile...\n");
+
+  uint32_t size = 2;
+  float mean[] = {2.0f, 4.0f};
+  float median[] = {1.0f, 3.0f};
+  float max[] = {4.0f, 6.0f};
+  float min[] = {1.5f, 2.5f};
+
+  float output[2] = {0.0f};
+
+  // Test NULL and size 0 checks
+  TEST_ASSERT(!get_morphed_profile(NULL, mean, median, max, min, size, 0.5f),
+              "morphed NULL output");
+  TEST_ASSERT(!get_morphed_profile(output, NULL, median, max, min, size, 0.5f),
+              "morphed NULL mean");
+  TEST_ASSERT(!get_morphed_profile(output, mean, median, max, min, 0, 0.5f),
+              "morphed size 0");
+
+  // Test positive aggressiveness (morph mean -> max)
+  // aggressiveness = 0.5
+  // output[0] = mean[0]*(1-0.5) + max[0]*0.5 = 2.0*0.5 + 4.0*0.5 = 3.0
+  // Clamped with min[0] (1.5) -> 3.0
+  // output[1] = mean[1]*(1-0.5) + max[1]*0.5 = 4.0*0.5 + 6.0*0.5 = 5.0
+  // Clamped with min[1] (2.5) -> 5.0
+  TEST_ASSERT(get_morphed_profile(output, mean, median, max, min, size, 0.5f),
+              "morphed aggressiveness > 0");
+  TEST_FLOAT_CLOSE(output[0], 3.0f, 1e-6f);
+  TEST_FLOAT_CLOSE(output[1], 5.0f, 1e-6f);
+
+  // Test negative aggressiveness (morph mean -> median)
+  // aggressiveness = -0.5, t = 0.5
+  // output[0] = mean[0]*(1-0.5) + median[0]*0.5 = 2.0*0.5 + 1.0*0.5 = 1.5
+  // Clamped with min[0] (1.5) -> 1.5
+  // output[1] = mean[1]*(1-0.5) + median[1]*0.5 = 4.0*0.5 + 3.0*0.5 = 3.5
+  // Clamped with min[1] (2.5) -> 3.5
+  TEST_ASSERT(get_morphed_profile(output, mean, median, max, min, size, -0.5f),
+              "morphed aggressiveness < 0");
+  TEST_FLOAT_CLOSE(output[0], 1.5f, 1e-6f);
+  TEST_FLOAT_CLOSE(output[1], 3.5f, 1e-6f);
+
+  // Test negative aggressiveness clamping with min profile
+  // aggressiveness = -1.0, t = 1.0
+  // output[0] = mean[0]*0.0 + median[0]*1.0 = 1.0
+  // Clamped with min[0] (1.5) -> should clamp to 1.5
+  TEST_ASSERT(get_morphed_profile(output, mean, median, max, min, size, -1.0f),
+              "morphed aggressiveness clamping");
+  TEST_FLOAT_CLOSE(output[0], 1.5f, 1e-6f);
+
+  printf("✓ get_morphed_profile tests passed\n");
+}
+
+int main(void) {
+  printf("Running spectral_utils tests...\n\n");
+
+  test_get_fft_window();
+  test_initialize_spectrum_with_value();
+  test_min_max_spectrum_float();
+  test_fft_frequency_conversions();
+  test_get_rolling_mean_spectrum();
+  test_get_rolling_median_spectrum();
+  test_smooth_spectrum();
+  test_interpolate_spectrum_gaps();
+  test_get_morphed_profile();
+
+  printf("\n✅ All spectral_utils tests passed!\n");
+  return 0;
+}

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -8,7 +8,6 @@
 
 // Include internal headers for testing
 #include "../src/shared/utils/spectral_features.h"
-#include "../src/shared/utils/spectral_utils.h"
 #include "shared/utils/general_utils.h"
 
 #define TEST_ASSERT(condition, message)                                        \
@@ -156,139 +155,6 @@ void test_remap_percentage_log_like_unity(void) {
   printf("✓ remap_percentage_log_like_unity tests passed\n");
 }
 
-void test_get_fft_window(void) {
-  printf("Testing get_fft_window...\n");
-
-  uint32_t fft_size = 1024;
-  float window[1024];
-
-  // Test HANN
-  TEST_ASSERT(get_fft_window(window, fft_size, HANN_WINDOW),
-              "HANN should succeed");
-  // Hann window at endpoints should be 0
-  TEST_FLOAT_CLOSE(window[0], 0.0f, 1e-6f);
-  // Hann window at middle should be around 1.0 (or slightly less depending on
-  // implementation)
-  TEST_ASSERT(window[512] > 0.9f, "Hann middle should be high");
-
-  // Test HAMMING
-  TEST_ASSERT(get_fft_window(window, fft_size, HAMMING_WINDOW),
-              "HAMMING should succeed");
-  // Hamming at endpoint is NOT zero (typically 0.08)
-  TEST_ASSERT(window[0] > 0.07f && window[0] < 0.09f, "Hamming endpoint check");
-
-  printf("✓ get_fft_window tests passed\n");
-}
-
-void test_initialize_spectrum_with_value(void) {
-  printf("Testing initialize_spectrum_with_value...\n");
-
-  uint32_t size = 100;
-  float spectrum[100];
-
-  TEST_ASSERT(initialize_spectrum_with_value(spectrum, size, 42.0f),
-              "Init should succeed");
-  for (uint32_t i = 0; i < size; i++) {
-    TEST_FLOAT_CLOSE(spectrum[i], 42.0f, 1e-6f);
-  }
-
-  printf("✓ initialize_spectrum_with_value tests passed\n");
-}
-
-void test_fft_frequency_conversions(void) {
-  printf("Testing fft_bin_to_freq and freq_to_fft_bin...\n");
-
-  uint32_t sr = 44100;
-  uint32_t fft_size = 1024;
-
-  // DC bin should be 0 Hz
-  TEST_FLOAT_CLOSE(fft_bin_to_freq(0, sr, fft_size), 0.0f, 1e-6f);
-  TEST_ASSERT(freq_to_fft_bin(0.0f, sr, fft_size) == 0, "0 Hz -> bin 0");
-
-  // Nyquist bin (fft_size/2) should be sr/2
-  float nyquist_freq = (float)sr / 2.0f;
-  TEST_FLOAT_CLOSE(fft_bin_to_freq(512, sr, fft_size), nyquist_freq, 1e-6f);
-  TEST_ASSERT(freq_to_fft_bin(nyquist_freq, sr, fft_size) == 512,
-              "Nyquist -> bin 512");
-
-  // Half way to Nyquist
-  float mid_freq = nyquist_freq / 2.0f;
-  TEST_FLOAT_CLOSE(fft_bin_to_freq(256, sr, fft_size), mid_freq, 1e-6f);
-  TEST_ASSERT(freq_to_fft_bin(mid_freq, sr, fft_size) == 256,
-              "Mid freq -> bin 256");
-
-  printf("✓ fft frequency conversion tests passed\n");
-}
-
-void test_min_max_spectrum_float(void) {
-  printf("Testing min_spectrum_float and max_spectrum_float...\n");
-
-  uint32_t size = 4;
-  float s1[] = {1.0f, 10.0f, 5.0f, 2.0f};
-  float s2[] = {2.0f, 5.0f, 5.0f, 1.0f};
-
-  float s1_min[] = {1.0f, 10.0f, 5.0f, 2.0f};
-  min_spectrum_float(s1_min, s2, size);
-  TEST_FLOAT_CLOSE(s1_min[0], 1.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(s1_min[1], 5.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(s1_min[2], 5.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(s1_min[3], 1.0f, 1e-6f);
-
-  float s1_max[] = {1.0f, 10.0f, 5.0f, 2.0f};
-  max_spectrum_float(s1_max, s2, size);
-  TEST_FLOAT_CLOSE(s1_max[0], 2.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(s1_max[1], 10.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(s1_max[2], 5.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(s1_max[3], 2.0f, 1e-6f);
-
-  printf("✓ min/max spectrum float tests passed\n");
-}
-
-void test_spectral_utils_null_and_edge_cases(void) {
-  printf("Testing spectral_utils NULL pointer and edge cases...\n");
-
-  float spectrum[10] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f,
-                        6.0f, 7.0f, 8.0f, 9.0f, 10.0f};
-  float spectrum2[10] = {10.0f, 9.0f, 8.0f, 7.0f, 6.0f,
-                         5.0f,  4.0f, 3.0f, 2.0f, 1.0f};
-
-  // Test NULL pointer handling
-  TEST_ASSERT(!initialize_spectrum_with_value(NULL, 10, 1.0f),
-              "initialize_spectrum_with_value should fail with NULL");
-  TEST_ASSERT(!initialize_spectrum_with_value(spectrum, 0, 1.0f),
-              "initialize_spectrum_with_value should fail with size 0");
-
-  TEST_ASSERT(!min_spectrum_float(NULL, spectrum2, 10),
-              "min_spectrum_float should fail with NULL spectrum_one");
-  TEST_ASSERT(!min_spectrum_float(spectrum, NULL, 10),
-              "min_spectrum_float should fail with NULL spectrum_two");
-  TEST_ASSERT(!min_spectrum_float(spectrum, spectrum2, 0),
-              "min_spectrum_float should fail with size 0");
-
-  TEST_ASSERT(!max_spectrum_float(NULL, spectrum2, 10),
-              "max_spectrum_float should fail with NULL spectrum_one");
-  TEST_ASSERT(!max_spectrum_float(spectrum, NULL, 10),
-              "max_spectrum_float should fail with NULL spectrum_two");
-  TEST_ASSERT(!max_spectrum_float(spectrum, spectrum2, 0),
-              "max_spectrum_float should fail with size 0");
-
-  // Test get_fft_window edge cases
-  float window[10];
-  TEST_ASSERT(!get_fft_window(NULL, 10, HANN_WINDOW),
-              "get_fft_window should fail with NULL");
-  TEST_ASSERT(!get_fft_window(window, 0, HANN_WINDOW),
-              "get_fft_window should fail with size 0");
-
-  // Test BLACKMAN and VORBIS windows
-  float bwindow[64];
-  TEST_ASSERT(get_fft_window(bwindow, 64, BLACKMAN_WINDOW),
-              "BLACKMAN window should succeed");
-  TEST_ASSERT(get_fft_window(bwindow, 64, VORBIS_WINDOW),
-              "VORBIS window should succeed");
-
-  printf("✓ spectral_utils NULL/edge case tests passed\n");
-}
-
 int main(void) {
   printf("Running utility function tests...\n\n");
 
@@ -297,12 +163,6 @@ int main(void) {
   test_get_next_divisible_two();
   test_get_next_power_two();
   test_remap_percentage_log_like_unity();
-  test_get_fft_window();
-  test_initialize_spectrum_with_value();
-
-  test_fft_frequency_conversions();
-  test_min_max_spectrum_float();
-  test_spectral_utils_null_and_edge_cases();
 
   test_spectral_features();
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -195,18 +195,6 @@ void test_initialize_spectrum_with_value(void) {
   printf("✓ initialize_spectrum_with_value tests passed\n");
 }
 
-void test_spectral_min_max(void) {
-  printf("Testing max_spectral_value and min_spectral_value...\n");
-
-  float spectrum[] = {1.0f, 5.0f, 2.0f, 10.0f, -3.0f, 4.0f};
-  uint32_t size = 6;
-
-  TEST_FLOAT_CLOSE(max_spectral_value(spectrum, size), 10.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(min_spectral_value(spectrum, size), -3.0f, 1e-6f);
-
-  printf("✓ spectral min/max tests passed\n");
-}
-
 void test_fft_frequency_conversions(void) {
   printf("Testing fft_bin_to_freq and freq_to_fft_bin...\n");
 
@@ -270,12 +258,6 @@ void test_spectral_utils_null_and_edge_cases(void) {
   TEST_ASSERT(!initialize_spectrum_with_value(spectrum, 0, 1.0f),
               "initialize_spectrum_with_value should fail with size 0");
 
-  TEST_FLOAT_CLOSE(max_spectral_value(NULL, 10), 0.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(max_spectral_value(spectrum, 0), 0.0f, 1e-6f);
-
-  TEST_FLOAT_CLOSE(min_spectral_value(NULL, 10), 0.0f, 1e-6f);
-  TEST_FLOAT_CLOSE(min_spectral_value(spectrum, 0), 0.0f, 1e-6f);
-
   TEST_ASSERT(!min_spectrum_float(NULL, spectrum2, 10),
               "min_spectrum_float should fail with NULL spectrum_one");
   TEST_ASSERT(!min_spectrum_float(spectrum, NULL, 10),
@@ -289,24 +271,6 @@ void test_spectral_utils_null_and_edge_cases(void) {
               "max_spectrum_float should fail with NULL spectrum_two");
   TEST_ASSERT(!max_spectrum_float(spectrum, spectrum2, 0),
               "max_spectrum_float should fail with size 0");
-
-  // Test double version edge cases
-  double dspectrum[10] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
-  double dspectrum2[10] = {10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
-
-  TEST_ASSERT(!min_spectrum_double(NULL, dspectrum2, 10),
-              "min_spectrum_double should fail with NULL");
-  TEST_ASSERT(!min_spectrum_double(dspectrum, NULL, 10),
-              "min_spectrum_double should fail with NULL");
-  TEST_ASSERT(!min_spectrum_double(dspectrum, dspectrum2, 0),
-              "min_spectrum_double should fail with size 0");
-
-  TEST_ASSERT(!max_spectrum_double(NULL, dspectrum2, 10),
-              "max_spectrum_double should fail with NULL");
-  TEST_ASSERT(!max_spectrum_double(dspectrum, NULL, 10),
-              "max_spectrum_double should fail with NULL");
-  TEST_ASSERT(!max_spectrum_double(dspectrum, dspectrum2, 0),
-              "max_spectrum_double should fail with size 0");
 
   // Test get_fft_window edge cases
   float window[10];
@@ -335,7 +299,7 @@ int main(void) {
   test_remap_percentage_log_like_unity();
   test_get_fft_window();
   test_initialize_spectrum_with_value();
-  test_spectral_min_max();
+
   test_fft_frequency_conversions();
   test_min_max_spectrum_float();
   test_spectral_utils_null_and_edge_cases();


### PR DESCRIPTION
Removes dead functions (min_spectrum_double, max_spectrum_double, min_spectral_value, max_spectral_value, direct_matrix_to_vector_spectral_convolution, spectral_flux), unused critical band scales (MEL_SCALE, OCTAVE_SCALE), and simplifies general utilities/whitening to eliminate over-engineering.