### PR TITLE
feat(hpss): implement zero-latency sliding HPSS with transient preservation

### DIFF
--- a/examples/denoiser_demo.c
+++ b/examples/denoiser_demo.c
@@ -96,7 +96,8 @@ int main(int argc, char** argv) {
           .reduction_amount = 20.F,
           .smoothing_factor = 0.F,
           .whitening_factor = 50.F,
-          .masking_depth = 0.5F};
+          .masking_depth = 0.5F,
+          .hpss_quality_mode = 1};
 
   static struct option long_options[] = {
       {"reduction", required_argument, 0, 'r'},

--- a/examples/denoiser_demo.c
+++ b/examples/denoiser_demo.c
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
           .smoothing_factor = 0.F,
           .whitening_factor = 50.F,
           .masking_depth = 0.5F,
-          .hpss_quality_mode = 1};
+          .hpss_enable = 1};
 
   static struct option long_options[] = {
       {"reduction", required_argument, 0, 'r'},

--- a/include/specbleach_2d_denoiser.h
+++ b/include/specbleach_2d_denoiser.h
@@ -95,12 +95,8 @@ typedef struct SpectralBleach2DDenoiserParameters {
   /* Tonal Separation */
   float tonal_reduction; // 0.0 to 1.0: Independent reduction for tones
 
-  /* HPSS quality mode (0 = Off, 1 = Low, 2 = Mid, 3 = High). Default: 0 (Off)
-   */
-  int hpss_quality_mode;
-
-  /* HPSS transient detection sensitivity (0.0 to 1.0). Default: 0.5 */
-  float hpss_sensitivity;
+  /* Enable HPSS transient protection (0 = disabled, 1 = enabled). Default: 1 */
+  int hpss_enable;
 
   /* Noise Profile Offset — shifts the noise threshold up/down in dB.
    * Positive values make detection more aggressive (more noise removed).

--- a/include/specbleach_2d_denoiser.h
+++ b/include/specbleach_2d_denoiser.h
@@ -99,6 +99,9 @@ typedef struct SpectralBleach2DDenoiserParameters {
    */
   int hpss_quality_mode;
 
+  /* HPSS transient detection sensitivity (0.0 to 1.0). Default: 0.5 */
+  float hpss_sensitivity;
+
   /* Noise Profile Offset — shifts the noise threshold up/down in dB.
    * Positive values make detection more aggressive (more noise removed).
    * Default: 2.0, Range: [-6.0, +6.0] */
@@ -222,6 +225,12 @@ uint32_t specbleach_2d_get_tonal_peaks_for_profile(
  */
 const float* specbleach_2d_get_active_noise_profile(
     SpectralBleachHandle instance);
+
+/**
+ * Returns true if a transient was detected and protected by HPSS in the last
+ * processed frame.
+ */
+bool specbleach_2d_is_transient_detected(SpectralBleachHandle instance);
 
 #ifdef __cplusplus
 }

--- a/include/specbleach_denoiser.h
+++ b/include/specbleach_denoiser.h
@@ -77,12 +77,8 @@ typedef struct SpectralBleachDenoiserParameters {
   /* Tonal Separation */
   float tonal_reduction; // 0.0 to 1.0: Independent reduction for tones
 
-  /* HPSS quality mode (0 = Off, 1 = Low, 2 = Mid, 3 = High). Default: 0 (Off)
-   */
-  int hpss_quality_mode;
-
-  /* HPSS transient detection sensitivity (0.0 to 1.0). Default: 0.5 */
-  float hpss_sensitivity;
+  /* Enable HPSS transient protection (0 = disabled, 1 = enabled). Default: 1 */
+  int hpss_enable;
 
   /* Noise Profile Offset — shifts the noise threshold up/down in dB.
    * Positive values make detection more aggressive (more noise removed).

--- a/include/specbleach_denoiser.h
+++ b/include/specbleach_denoiser.h
@@ -81,6 +81,9 @@ typedef struct SpectralBleachDenoiserParameters {
    */
   int hpss_quality_mode;
 
+  /* HPSS transient detection sensitivity (0.0 to 1.0). Default: 0.5 */
+  float hpss_sensitivity;
+
   /* Noise Profile Offset — shifts the noise threshold up/down in dB.
    * Positive values make detection more aggressive (more noise removed).
    * Default: 2.0, Range: [-6.0, +6.0] */
@@ -188,6 +191,12 @@ uint32_t specbleach_get_tonal_peaks_for_profile(SpectralBleachHandle instance,
  * Returns a pointer to the active morphed noise profile array.
  */
 const float* specbleach_get_active_noise_profile(SpectralBleachHandle instance);
+
+/**
+ * Returns true if a transient was detected and protected by HPSS in the last
+ * processed frame.
+ */
+bool specbleach_is_transient_detected(SpectralBleachHandle instance);
 
 #ifdef __cplusplus
 }

--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -356,7 +356,8 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   };
   denoiser_profile_core_update(profile_params, reference_spectrum);
 
-  // 2.1 Align internal state and output to the delayed frame (temporal plumbing)
+  // 2.1 Align internal state and output to the delayed frame (temporal
+  // plumbing)
   const uint32_t delay_frames =
       hpss_filter_get_latency_frames(self->hpss_filter);
 
@@ -436,12 +437,14 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     }
   }
 
-  // 2. Recombine: Harmonic gets G_H suppression, Percussive gets unity pass-through
+  // 2. Recombine: Harmonic gets G_H suppression, Percussive gets unity
+  // pass-through
   for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
     float w_h = self->mask_harmonic[k];
     float w_p = self->mask_percussive[k];
 
-    // G_final blends Wiener suppression on stationary content with unity gain on transient bursts
+    // G_final blends Wiener suppression on stationary content with unity gain
+    // on transient bursts
     float combined_gain = (w_h * self->g_h[k]) + w_p;
     self->gain_spectrum[k] = fminf(fmaxf(combined_gain, 0.0f), 1.0f);
   }

--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -312,9 +312,7 @@ bool load_reduction_parameters(SpectralProcessorHandle instance,
   self->aggressiveness = parameters.aggressiveness;
 
   if (self->hpss_filter) {
-    hpss_filter_set_quality_mode(self->hpss_filter,
-                                 (HpssQualityMode)parameters.hpss_quality_mode);
-    hpss_filter_set_sensitivity(self->hpss_filter, parameters.hpss_sensitivity);
+    hpss_filter_set_enabled(self->hpss_filter, parameters.hpss_enable != 0);
   }
 
   return true;

--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -18,6 +18,7 @@
 #include "shared/utils/spectral_smoother.h"
 #include "shared/utils/spectral_utils.h"
 #include <float.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -60,7 +61,6 @@ typedef struct SbSpectralDenoiser {
   float* mask_harmonic;
   float* mask_percussive;
   float* g_h;
-  float* g_p;
 
   int last_adaptive_state;
   int last_noise_estimation_method;
@@ -189,8 +189,6 @@ SpectralProcessorHandle spectral_denoiser_initialize(
 
   HpssConfig hpss_cfg = {
       .real_spectrum_size = self->real_spectrum_size,
-      .time_window_size = HPSS_TIME_WINDOW_1D_DEFAULT,
-      .freq_window_size = HPSS_FREQ_WINDOW_1D_DEFAULT,
   };
   self->hpss_filter = hpss_filter_initialize(hpss_cfg);
   self->delayed_magnitude =
@@ -199,12 +197,11 @@ SpectralProcessorHandle spectral_denoiser_initialize(
   self->mask_percussive =
       (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->g_h = (float*)calloc(self->fft_size, sizeof(float));
-  self->g_p = (float*)calloc(self->fft_size, sizeof(float));
 
   if (!self->noise_floor_manager || !self->masking_veto ||
       !self->suppression_engine || !self->hpss_filter ||
       !self->delayed_magnitude || !self->mask_harmonic ||
-      !self->mask_percussive || !self->g_h || !self->g_p) {
+      !self->mask_percussive || !self->g_h) {
     spectral_denoiser_free(self);
     return NULL;
   }
@@ -281,9 +278,6 @@ void spectral_denoiser_free(SpectralProcessorHandle instance) {
   if (self->g_h) {
     free(self->g_h);
   }
-  if (self->g_p) {
-    free(self->g_p);
-  }
 
   free(self);
 }
@@ -320,6 +314,7 @@ bool load_reduction_parameters(SpectralProcessorHandle instance,
   if (self->hpss_filter) {
     hpss_filter_set_quality_mode(self->hpss_filter,
                                  (HpssQualityMode)parameters.hpss_quality_mode);
+    hpss_filter_set_sensitivity(self->hpss_filter, parameters.hpss_sensitivity);
   }
 
   return true;
@@ -361,16 +356,29 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   };
   denoiser_profile_core_update(profile_params, reference_spectrum);
 
-  // 2.1 Align internal state and output to the delayed frame (temporal
-  // plumbing)
+  // 2.1 Align internal state and output to the delayed frame (temporal plumbing)
+  const uint32_t delay_frames =
+      hpss_filter_get_latency_frames(self->hpss_filter);
+
+  // 1. Push incoming frames
   spectral_circular_buffer_push(self->circular_buffer, self->layer_fft,
                                 fft_spectrum);
   spectral_circular_buffer_push(self->circular_buffer, self->layer_noise,
                                 self->noise_spectrum);
 
-  const uint32_t delay_frames =
-      hpss_filter_get_latency_frames(self->hpss_filter);
+  // 2. Process HPSS (internally produces masks aligned at delay_frames)
+  if (!hpss_filter_process(self->hpss_filter, reference_spectrum,
+                           self->noise_spectrum, self->delayed_magnitude,
+                           self->mask_harmonic, self->mask_percussive)) {
+    memcpy(self->delayed_magnitude, reference_spectrum,
+           self->real_spectrum_size * sizeof(float));
+    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+      self->mask_harmonic[k] = 1.0f;
+      self->mask_percussive[k] = 0.0f;
+    }
+  }
 
+  // 3. Retrieve aligned FFT and noise at the exact same delay
   float* delayed_spectrum = spectral_circular_buffer_retrieve(
       self->circular_buffer, self->layer_fft, delay_frames);
   float* delayed_noise = spectral_circular_buffer_retrieve(
@@ -388,19 +396,6 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     memcpy(fft_spectrum, delayed_spectrum, self->fft_size * sizeof(float));
   }
 
-  // 3. Denoising Stage: HPSS dual-path gain calculation and psychoacoustic
-  // constraints
-  if (!hpss_filter_process(self->hpss_filter, reference_spectrum,
-                           self->delayed_magnitude, self->mask_harmonic,
-                           self->mask_percussive)) {
-    memcpy(self->delayed_magnitude, reference_spectrum,
-           self->real_spectrum_size * sizeof(float));
-    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-      self->mask_harmonic[k] = 1.0f;
-      self->mask_percussive[k] = 0.0f;
-    }
-  }
-
   float* input_magnitude = self->delayed_magnitude;
 
   // 3.1. Calculate SNR-dependent oversubtraction factors (Alpha/Beta)
@@ -412,9 +407,6 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
                                delayed_noise, suppression_params, self->alpha,
                                self->beta);
 
-  float onset_ratio = hpss_filter_get_onset_ratio(self->hpss_filter);
-  apply_onset_alpha_ducking(self->alpha, self->real_spectrum_size, onset_ratio);
-
   // 3.2. Detect tonal components and boost alpha at tonal bins
   tonal_reducer_run(self->tonal_reducer, delayed_noise,
                     get_noise_profile(self->noise_profile, CV_MASK),
@@ -425,9 +417,8 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   masking_veto_apply(self->masking_veto, input_magnitude, delayed_noise, NULL,
                      self->alpha, self->denoise_parameters.masking_depth);
 
-  // 3.4. Dual-Path Gain Engine
-  // 3.4a. Calculate Raw Harmonic Gain G_H and apply temporal & spatial gain
-  // smoothing
+  // 3.4. Gain Calculation & HPSS Combination
+  // 1. Calculate heavily smoothed Harmonic Gain (G_H) on stationary path
   calculate_gains(self->real_spectrum_size, self->fft_size, input_magnitude,
                   delayed_noise, self->g_h, self->alpha, self->beta,
                   self->gain_calculation_type);
@@ -445,17 +436,17 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     }
   }
 
-  // 3.4b. Calculate Raw Percussive Gain G_P (Bypass temporal smoothing
-  // completely)
-  calculate_gains(self->real_spectrum_size, self->fft_size, input_magnitude,
-                  delayed_noise, self->g_p, self->alpha, self->beta,
-                  self->gain_calculation_type);
-
-  // 3.4c. Recombine gains: G_final = W_H * G_H + W_P * G_P
+  // 2. Recombine: Harmonic gets G_H suppression, Percussive gets unity pass-through
   for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-    self->gain_spectrum[k] = self->mask_harmonic[k] * self->g_h[k] +
-                             self->mask_percussive[k] * self->g_p[k];
+    float w_h = self->mask_harmonic[k];
+    float w_p = self->mask_percussive[k];
+
+    // G_final blends Wiener suppression on stationary content with unity gain on transient bursts
+    float combined_gain = (w_h * self->g_h[k]) + w_p;
+    self->gain_spectrum[k] = fminf(fmaxf(combined_gain, 0.0f), 1.0f);
   }
+  sb_apply_spectral_symmetry(self->gain_spectrum, self->real_spectrum_size,
+                             self->fft_size);
 
   // 4. Post-Processing: Final gain management and mixing
   DenoiserPostProcessParams post_params = {
@@ -528,4 +519,12 @@ uint32_t spectral_denoiser_get_latency_frames(
   }
   SbSpectralDenoiser* self = (SbSpectralDenoiser*)instance;
   return hpss_filter_get_latency_frames(self->hpss_filter);
+}
+
+bool spectral_denoiser_is_transient_detected(SpectralProcessorHandle instance) {
+  if (!instance) {
+    return false;
+  }
+  SbSpectralDenoiser* self = (SbSpectralDenoiser*)instance;
+  return hpss_filter_is_transient_detected(self->hpss_filter);
 }

--- a/src/processors/denoiser/spectral_denoiser.h
+++ b/src/processors/denoiser/spectral_denoiser.h
@@ -38,8 +38,7 @@ typedef struct DenoiserParameters {
   float suppression_strength;
   float aggressiveness;  /**< -1.0 (Median/Min) to 1.0 (Max), 0.0 (Mean) */
   float tonal_reduction; /**< 0.0 to 1.0 (Phase 3) */
-  int hpss_quality_mode; /**< 0=Off, 1=Low, 2=Medium, 3=High */
-  float hpss_sensitivity;
+  int hpss_enable;       /**< 0=disabled, 1=enabled */
   float noise_profile_offset_linear; /**< Linear scalar for noise profile */
   const float* reduction_curve_bias; /**< Per-bin dB bias, NULL = disabled */
   bool reduction_curve_enabled;

--- a/src/processors/denoiser/spectral_denoiser.h
+++ b/src/processors/denoiser/spectral_denoiser.h
@@ -39,6 +39,7 @@ typedef struct DenoiserParameters {
   float aggressiveness;  /**< -1.0 (Median/Min) to 1.0 (Max), 0.0 (Mean) */
   float tonal_reduction; /**< 0.0 to 1.0 (Phase 3) */
   int hpss_quality_mode; /**< 0=Off, 1=Low, 2=Medium, 3=High */
+  float hpss_sensitivity;
   float noise_profile_offset_linear; /**< Linear scalar for noise profile */
   const float* reduction_curve_bias; /**< Per-bin dB bias, NULL = disabled */
   bool reduction_curve_enabled;
@@ -59,5 +60,6 @@ const float* spectral_denoiser_get_active_noise_profile(
     SpectralProcessorHandle instance);
 void spectral_denoiser_reset_noise_profile(SpectralProcessorHandle instance);
 uint32_t spectral_denoiser_get_latency_frames(SpectralProcessorHandle instance);
+bool spectral_denoiser_is_transient_detected(SpectralProcessorHandle instance);
 
 #endif

--- a/src/processors/denoiser2d/spectral_2d_denoiser.c
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.c
@@ -393,10 +393,10 @@ bool load_2d_reduction_parameters(SpectralProcessorHandle instance,
   // Update NLM h parameter based on smoothing factor (scales h up to 5.0F for
   // strong NLM patch smoothing)
   if (self->nlm_filter) {
-    nlm_filter_set_h_parameter(self->nlm_filter,
-                               (parameters.smoothing_factor > 0.0F)
-                                   ? (0.5F + parameters.smoothing_factor * 4.5F)
-                                   : 0.0F);
+    nlm_filter_set_h_parameter(
+        self->nlm_filter, (parameters.smoothing_factor > 0.0F)
+                              ? (0.5F + (parameters.smoothing_factor * 4.5F))
+                              : 0.0F);
   }
 
   return true;
@@ -530,8 +530,7 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
     memcpy(self->mask_percussive, aligned_wp,
            self->real_spectrum_size * sizeof(float));
   } else {
-    memset(self->mask_percussive, 0,
-           self->real_spectrum_size * sizeof(float));
+    memset(self->mask_percussive, 0, self->real_spectrum_size * sizeof(float));
   }
   if (aligned_mag) {
     memcpy(self->delayed_magnitude, aligned_mag,

--- a/src/processors/denoiser2d/spectral_2d_denoiser.c
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.c
@@ -387,9 +387,7 @@ bool load_2d_reduction_parameters(SpectralProcessorHandle instance,
   self->aggressiveness = parameters.aggressiveness;
 
   if (self->hpss_filter) {
-    hpss_filter_set_quality_mode(self->hpss_filter,
-                                 (HpssQualityMode)parameters.hpss_quality_mode);
-    hpss_filter_set_sensitivity(self->hpss_filter, parameters.hpss_sensitivity);
+    hpss_filter_set_enabled(self->hpss_filter, parameters.hpss_enable != 0);
   }
 
   // Update NLM h parameter based on smoothing factor (scales h up to 5.0F for
@@ -523,9 +521,16 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
   if (aligned_wh) {
     memcpy(self->mask_harmonic, aligned_wh,
            self->real_spectrum_size * sizeof(float));
+  } else {
+    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+      self->mask_harmonic[k] = 1.0f;
+    }
   }
   if (aligned_wp) {
     memcpy(self->mask_percussive, aligned_wp,
+           self->real_spectrum_size * sizeof(float));
+  } else {
+    memset(self->mask_percussive, 0,
            self->real_spectrum_size * sizeof(float));
   }
   if (aligned_mag) {

--- a/src/processors/denoiser2d/spectral_2d_denoiser.c
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.c
@@ -449,9 +449,9 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
                                 self->noise_spectrum);
 
   // 2.1.2 HPSS Process (operates on current reference_spectrum, produces masks)
-  if (!hpss_filter_process(
-          self->hpss_filter, reference_spectrum, self->noise_spectrum,
-          self->delayed_magnitude, self->mask_harmonic, self->mask_percussive)) {
+  if (!hpss_filter_process(self->hpss_filter, reference_spectrum,
+                           self->noise_spectrum, self->delayed_magnitude,
+                           self->mask_harmonic, self->mask_percussive)) {
     memcpy(self->delayed_magnitude, reference_spectrum,
            self->real_spectrum_size * sizeof(float));
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
@@ -460,7 +460,8 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
     }
   }
 
-  // Push HPSS outputs to circular buffer to allow exact temporal alignment with NLM
+  // Push HPSS outputs to circular buffer to allow exact temporal alignment with
+  // NLM
   spectral_circular_buffer_push(self->circular_buffer, self->layer_hpss_wh,
                                 self->mask_harmonic);
   spectral_circular_buffer_push(self->circular_buffer, self->layer_hpss_wp,
@@ -474,8 +475,7 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
   nlm_filter_push_frame(self->nlm_filter, self->snr_frame);
 
   const uint32_t nlm_delay = nlm_filter_get_latency_frames(self->nlm_filter);
-  const uint32_t hpss_delay =
-      hpss_filter_get_latency_frames(self->hpss_filter);
+  const uint32_t hpss_delay = hpss_filter_get_latency_frames(self->hpss_filter);
   const uint32_t total_delay =
       (hpss_delay > nlm_delay) ? hpss_delay : nlm_delay;
 
@@ -503,17 +503,13 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
   float* delayed_noise = spectral_circular_buffer_retrieve(
       self->circular_buffer, self->layer_noise, total_delay);
   float* smoothed_magnitude = spectral_circular_buffer_retrieve(
-      self->circular_buffer, self->layer_nlm_smoothed,
-      total_delay - nlm_delay);
+      self->circular_buffer, self->layer_nlm_smoothed, total_delay - nlm_delay);
   float* aligned_wh = spectral_circular_buffer_retrieve(
-      self->circular_buffer, self->layer_hpss_wh,
-      total_delay - hpss_delay);
+      self->circular_buffer, self->layer_hpss_wh, total_delay - hpss_delay);
   float* aligned_wp = spectral_circular_buffer_retrieve(
-      self->circular_buffer, self->layer_hpss_wp,
-      total_delay - hpss_delay);
+      self->circular_buffer, self->layer_hpss_wp, total_delay - hpss_delay);
   float* aligned_mag = spectral_circular_buffer_retrieve(
-      self->circular_buffer, self->layer_hpss_mag,
-      total_delay - hpss_delay);
+      self->circular_buffer, self->layer_hpss_mag, total_delay - hpss_delay);
 
   if (!delayed_spectrum) {
     delayed_spectrum = fft_spectrum;
@@ -569,12 +565,14 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
                   delayed_noise, self->g_h, self->alpha, self->beta,
                   self->gain_calculation_type);
 
-  // 2. Recombine: Harmonic gets G_H suppression, Percussive gets unity pass-through
+  // 2. Recombine: Harmonic gets G_H suppression, Percussive gets unity
+  // pass-through
   for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
     float w_h = self->mask_harmonic[k];
     float w_p = self->mask_percussive[k];
 
-    // G_final blends Wiener suppression on stationary content with unity gain on transient bursts
+    // G_final blends Wiener suppression on stationary content with unity gain
+    // on transient bursts
     float combined_gain = (w_h * self->g_h[k]) + w_p;
     self->gain_spectrum[k] = fminf(fmaxf(combined_gain, 0.0f), 1.0f);
   }

--- a/src/processors/denoiser2d/spectral_2d_denoiser.c
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.c
@@ -34,6 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "shared/denoiser_logic/processing/tonal_reducer.h"
 #include "shared/utils/spectral_circular_buffer.h"
 #include "shared/utils/spectral_utils.h"
+#include <math.h>
 #include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
@@ -64,6 +65,9 @@ typedef struct Spectral2DDenoiser {
   uint32_t layer_fft;
   uint32_t layer_noise;
   uint32_t layer_nlm_smoothed;
+  uint32_t layer_hpss_wh;
+  uint32_t layer_hpss_wp;
+  uint32_t layer_hpss_mag;
 
   SpectrumType spectrum_type;
   GainCalculationType gain_calculation_type;
@@ -82,7 +86,6 @@ typedef struct Spectral2DDenoiser {
   float* mask_harmonic;
   float* mask_percussive;
   float* g_h;
-  float* g_p;
 
   int last_adaptive_state;
   int last_noise_estimation_method;
@@ -193,9 +196,18 @@ SpectralProcessorHandle spectral_2d_denoiser_initialize(
       self->circular_buffer, self->real_spectrum_size);
   self->layer_nlm_smoothed = spectral_circular_buffer_add_layer(
       self->circular_buffer, self->real_spectrum_size);
+  self->layer_hpss_wh = spectral_circular_buffer_add_layer(
+      self->circular_buffer, self->real_spectrum_size);
+  self->layer_hpss_wp = spectral_circular_buffer_add_layer(
+      self->circular_buffer, self->real_spectrum_size);
+  self->layer_hpss_mag = spectral_circular_buffer_add_layer(
+      self->circular_buffer, self->real_spectrum_size);
 
   if (self->layer_fft == 0xFFFFFFFFU || self->layer_noise == 0xFFFFFFFFU ||
-      self->layer_nlm_smoothed == 0xFFFFFFFFU) {
+      self->layer_nlm_smoothed == 0xFFFFFFFFU ||
+      self->layer_hpss_wh == 0xFFFFFFFFU ||
+      self->layer_hpss_wp == 0xFFFFFFFFU ||
+      self->layer_hpss_mag == 0xFFFFFFFFU) {
     spectral_2d_denoiser_free(self);
     return NULL;
   }
@@ -254,8 +266,6 @@ SpectralProcessorHandle spectral_2d_denoiser_initialize(
 
   HpssConfig hpss_cfg = {
       .real_spectrum_size = self->real_spectrum_size,
-      .time_window_size = HPSS_TIME_WINDOW_2D_DEFAULT,
-      .freq_window_size = HPSS_FREQ_WINDOW_2D_DEFAULT,
   };
   self->hpss_filter = hpss_filter_initialize(hpss_cfg);
   self->delayed_magnitude =
@@ -264,11 +274,10 @@ SpectralProcessorHandle spectral_2d_denoiser_initialize(
   self->mask_percussive =
       (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->g_h = (float*)calloc(self->fft_size, sizeof(float));
-  self->g_p = (float*)calloc(self->fft_size, sizeof(float));
 
   if (!self->noise_floor_manager || !self->hpss_filter ||
       !self->delayed_magnitude || !self->mask_harmonic ||
-      !self->mask_percussive || !self->g_h || !self->g_p) {
+      !self->mask_percussive || !self->g_h) {
     spectral_2d_denoiser_free(self);
     return NULL;
   }
@@ -344,9 +353,6 @@ void spectral_2d_denoiser_free(SpectralProcessorHandle instance) {
   if (self->g_h) {
     free(self->g_h);
   }
-  if (self->g_p) {
-    free(self->g_p);
-  }
 
   free(self);
 }
@@ -383,6 +389,7 @@ bool load_2d_reduction_parameters(SpectralProcessorHandle instance,
   if (self->hpss_filter) {
     hpss_filter_set_quality_mode(self->hpss_filter,
                                  (HpssQualityMode)parameters.hpss_quality_mode);
+    hpss_filter_set_sensitivity(self->hpss_filter, parameters.hpss_sensitivity);
   }
 
   // Update NLM h parameter based on smoothing factor (scales h up to 5.0F for
@@ -441,11 +448,10 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
   spectral_circular_buffer_push(self->circular_buffer, self->layer_noise,
                                 self->noise_spectrum);
 
-  // 2.1.2 HPSS Process (operates on current reference_spectrum, outputs
-  // delayed_magnitude and masks at delay L_hpss)
-  if (!hpss_filter_process(self->hpss_filter, reference_spectrum,
-                           self->delayed_magnitude, self->mask_harmonic,
-                           self->mask_percussive)) {
+  // 2.1.2 HPSS Process (operates on current reference_spectrum, produces masks)
+  if (!hpss_filter_process(
+          self->hpss_filter, reference_spectrum, self->noise_spectrum,
+          self->delayed_magnitude, self->mask_harmonic, self->mask_percussive)) {
     memcpy(self->delayed_magnitude, reference_spectrum,
            self->real_spectrum_size * sizeof(float));
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
@@ -454,13 +460,22 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
     }
   }
 
+  // Push HPSS outputs to circular buffer to allow exact temporal alignment with NLM
+  spectral_circular_buffer_push(self->circular_buffer, self->layer_hpss_wh,
+                                self->mask_harmonic);
+  spectral_circular_buffer_push(self->circular_buffer, self->layer_hpss_wp,
+                                self->mask_percussive);
+  spectral_circular_buffer_push(self->circular_buffer, self->layer_hpss_mag,
+                                self->delayed_magnitude);
+
   // 2.1.3 Compute SNR for NLM using CURRENT noise and push frame
   nlm_filter_calculate_snr(self->nlm_filter, reference_spectrum,
                            self->noise_spectrum, self->snr_frame);
   nlm_filter_push_frame(self->nlm_filter, self->snr_frame);
 
   const uint32_t nlm_delay = nlm_filter_get_latency_frames(self->nlm_filter);
-  const uint32_t hpss_delay = hpss_filter_get_latency_frames(self->hpss_filter);
+  const uint32_t hpss_delay =
+      hpss_filter_get_latency_frames(self->hpss_filter);
   const uint32_t total_delay =
       (hpss_delay > nlm_delay) ? hpss_delay : nlm_delay;
 
@@ -488,7 +503,17 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
   float* delayed_noise = spectral_circular_buffer_retrieve(
       self->circular_buffer, self->layer_noise, total_delay);
   float* smoothed_magnitude = spectral_circular_buffer_retrieve(
-      self->circular_buffer, self->layer_nlm_smoothed, total_delay - nlm_delay);
+      self->circular_buffer, self->layer_nlm_smoothed,
+      total_delay - nlm_delay);
+  float* aligned_wh = spectral_circular_buffer_retrieve(
+      self->circular_buffer, self->layer_hpss_wh,
+      total_delay - hpss_delay);
+  float* aligned_wp = spectral_circular_buffer_retrieve(
+      self->circular_buffer, self->layer_hpss_wp,
+      total_delay - hpss_delay);
+  float* aligned_mag = spectral_circular_buffer_retrieve(
+      self->circular_buffer, self->layer_hpss_mag,
+      total_delay - hpss_delay);
 
   if (!delayed_spectrum) {
     delayed_spectrum = fft_spectrum;
@@ -497,7 +522,19 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
     delayed_noise = self->noise_spectrum;
   }
   if (!smoothed_magnitude) {
-    smoothed_magnitude = self->delayed_magnitude;
+    smoothed_magnitude = reference_spectrum;
+  }
+  if (aligned_wh) {
+    memcpy(self->mask_harmonic, aligned_wh,
+           self->real_spectrum_size * sizeof(float));
+  }
+  if (aligned_wp) {
+    memcpy(self->mask_percussive, aligned_wp,
+           self->real_spectrum_size * sizeof(float));
+  }
+  if (aligned_mag) {
+    memcpy(self->delayed_magnitude, aligned_mag,
+           self->real_spectrum_size * sizeof(float));
   }
 
   // Align output to delayed frame for post-processing
@@ -515,10 +552,6 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
                                delayed_noise, suppression_params, self->alpha,
                                self->beta);
 
-  float onset_ratio = hpss_filter_get_onset_ratio(self->hpss_filter);
-  apply_onset_alpha_ducking(self->alpha, self->real_spectrum_size, onset_ratio);
-  ;
-
   // 3.2 Detect tonal components and boost alpha at tonal bins
   tonal_reducer_run(self->tonal_reducer, delayed_noise,
                     get_noise_profile(self->noise_profile, CV_MASK),
@@ -530,24 +563,23 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
                      fft_spectrum, self->alpha,
                      self->parameters.nlm_masking_protection);
 
-  // 3.4 Dual-Path Gain Engine
-  // Calculate Harmonic Gain G_H from smoothed harmonic path (NLM smoothed
-  // magnitude)
+  // 3.4 Gain Calculation & HPSS Combination
+  // 1. Calculate heavily smoothed Harmonic Gain (G_H) on stationary path
   calculate_gains(self->real_spectrum_size, self->fft_size, smoothed_magnitude,
                   delayed_noise, self->g_h, self->alpha, self->beta,
                   self->gain_calculation_type);
 
-  // Calculate Percussive Gain G_P from raw delayed magnitude (bypassing NLM
-  // smoothing)
-  calculate_gains(self->real_spectrum_size, self->fft_size,
-                  self->delayed_magnitude, delayed_noise, self->g_p,
-                  self->alpha, self->beta, self->gain_calculation_type);
-
-  // Recombine gains: G_final = W_H * G_H + W_P * G_P
+  // 2. Recombine: Harmonic gets G_H suppression, Percussive gets unity pass-through
   for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-    self->gain_spectrum[k] = self->mask_harmonic[k] * self->g_h[k] +
-                             self->mask_percussive[k] * self->g_p[k];
+    float w_h = self->mask_harmonic[k];
+    float w_p = self->mask_percussive[k];
+
+    // G_final blends Wiener suppression on stationary content with unity gain on transient bursts
+    float combined_gain = (w_h * self->g_h[k]) + w_p;
+    self->gain_spectrum[k] = fminf(fmaxf(combined_gain, 0.0f), 1.0f);
   }
+  sb_apply_spectral_symmetry(self->gain_spectrum, self->real_spectrum_size,
+                             self->fft_size);
 
   // 4. Post-Processing: Final gain management and mixing
   DenoiserPostProcessParams post_params = {
@@ -642,4 +674,13 @@ void spectral_2d_denoiser_reset_noise_profile(
   }
   self->was_learning = false;
   self->last_adaptive_state = 0;
+}
+
+bool spectral_2d_denoiser_is_transient_detected(
+    SpectralProcessorHandle instance) {
+  if (!instance) {
+    return false;
+  }
+  Spectral2DDenoiser* self = (Spectral2DDenoiser*)instance;
+  return hpss_filter_is_transient_detected(self->hpss_filter);
 }

--- a/src/processors/denoiser2d/spectral_2d_denoiser.h
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.h
@@ -43,6 +43,7 @@ typedef struct Denoiser2DParameters {
   float aggressiveness;  /**< -1.0 (Median/Min) to 1.0 (Max), 0.0 (Mean) */
   float tonal_reduction; /**< 0.0 to 1.0 (Phase 3) */
   int hpss_quality_mode; /**< 0=Off, 1=Low, 2=Medium, 3=High */
+  float hpss_sensitivity;
   float noise_profile_offset_linear; /**< Linear scalar for noise profile */
   const float* reduction_curve_bias; /**< Per-bin dB bias, NULL = disabled */
   bool reduction_curve_enabled;
@@ -100,5 +101,7 @@ uint32_t spectral_2d_denoiser_get_peaks(SpectralProcessorHandle instance,
 const float* spectral_2d_denoiser_get_active_noise_profile(
     SpectralProcessorHandle instance);
 void spectral_2d_denoiser_reset_noise_profile(SpectralProcessorHandle instance);
+bool spectral_2d_denoiser_is_transient_detected(
+    SpectralProcessorHandle instance);
 
 #endif /* SPECTRAL_2D_DENOISER_H */

--- a/src/processors/denoiser2d/spectral_2d_denoiser.h
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.h
@@ -42,8 +42,7 @@ typedef struct Denoiser2DParameters {
   float suppression_strength;   /**< Suppression aggressiveness (0.0 to 1.0) */
   float aggressiveness;  /**< -1.0 (Median/Min) to 1.0 (Max), 0.0 (Mean) */
   float tonal_reduction; /**< 0.0 to 1.0 (Phase 3) */
-  int hpss_quality_mode; /**< 0=Off, 1=Low, 2=Medium, 3=High */
-  float hpss_sensitivity;
+  int hpss_enable;       /**< 0=disabled, 1=enabled */
   float noise_profile_offset_linear; /**< Linear scalar for noise profile */
   const float* reduction_curve_bias; /**< Per-bin dB bias, NULL = disabled */
   bool reduction_curve_enabled;

--- a/src/processors/specbleach_2d_denoiser.c
+++ b/src/processors/specbleach_2d_denoiser.c
@@ -230,3 +230,10 @@ const float* specbleach_2d_get_active_noise_profile(
                     self->spectral_2d_denoiser)
               : NULL;
 }
+
+bool specbleach_2d_is_transient_detected(SpectralBleachHandle instance) {
+  Sb2DDenoiser* self = (Sb2DDenoiser*)instance;
+  return self ? spectral_2d_denoiser_is_transient_detected(
+                    self->spectral_2d_denoiser)
+              : false;
+}

--- a/src/processors/specbleach_denoiser.c
+++ b/src/processors/specbleach_denoiser.c
@@ -223,3 +223,9 @@ const float* specbleach_get_active_noise_profile(
                     self->spectral_denoiser)
               : NULL;
 }
+
+bool specbleach_is_transient_detected(SpectralBleachHandle instance) {
+  SbSpectralDenoiser* self = (SbSpectralDenoiser*)instance;
+  return self ? spectral_denoiser_is_transient_detected(self->spectral_denoiser)
+              : false;
+}

--- a/src/processors/specbleach_processor_core.c
+++ b/src/processors/specbleach_processor_core.c
@@ -41,6 +41,9 @@ DenoiserParameters sb_denoiser_params_sanitize(
       .tonal_reduction =
           from_db_to_coefficient(parameters.tonal_reduction * -1.F),
       .hpss_quality_mode = parameters.hpss_quality_mode,
+      .hpss_sensitivity = (parameters.hpss_sensitivity > 0.0f)
+                              ? parameters.hpss_sensitivity
+                              : HPSS_SENSITIVITY_DEFAULT,
       .noise_profile_offset_linear =
           powf(10.0f, fmaxf(NOISE_PROFILE_OFFSET_MIN_DB,
                             fminf(NOISE_PROFILE_OFFSET_MAX_DB,
@@ -70,6 +73,9 @@ Denoiser2DParameters sb_denoiser_2d_params_sanitize(
       .tonal_reduction =
           from_db_to_coefficient(parameters.tonal_reduction * -1.F),
       .hpss_quality_mode = parameters.hpss_quality_mode,
+      .hpss_sensitivity = (parameters.hpss_sensitivity > 0.0f)
+                              ? parameters.hpss_sensitivity
+                              : HPSS_SENSITIVITY_DEFAULT,
       .noise_profile_offset_linear =
           powf(10.0f, fmaxf(NOISE_PROFILE_OFFSET_MIN_DB,
                             fminf(NOISE_PROFILE_OFFSET_MAX_DB,

--- a/src/processors/specbleach_processor_core.c
+++ b/src/processors/specbleach_processor_core.c
@@ -40,10 +40,7 @@ DenoiserParameters sb_denoiser_params_sanitize(
       .aggressiveness = parameters.aggressiveness,
       .tonal_reduction =
           from_db_to_coefficient(parameters.tonal_reduction * -1.F),
-      .hpss_quality_mode = parameters.hpss_quality_mode,
-      .hpss_sensitivity = (parameters.hpss_sensitivity > 0.0f)
-                              ? parameters.hpss_sensitivity
-                              : HPSS_SENSITIVITY_DEFAULT,
+      .hpss_enable = parameters.hpss_enable,
       .noise_profile_offset_linear =
           powf(10.0f, fmaxf(NOISE_PROFILE_OFFSET_MIN_DB,
                             fminf(NOISE_PROFILE_OFFSET_MAX_DB,
@@ -72,10 +69,7 @@ Denoiser2DParameters sb_denoiser_2d_params_sanitize(
       .aggressiveness = parameters.aggressiveness,
       .tonal_reduction =
           from_db_to_coefficient(parameters.tonal_reduction * -1.F),
-      .hpss_quality_mode = parameters.hpss_quality_mode,
-      .hpss_sensitivity = (parameters.hpss_sensitivity > 0.0f)
-                              ? parameters.hpss_sensitivity
-                              : HPSS_SENSITIVITY_DEFAULT,
+      .hpss_enable = parameters.hpss_enable,
       .noise_profile_offset_linear =
           powf(10.0f, fmaxf(NOISE_PROFILE_OFFSET_MIN_DB,
                             fminf(NOISE_PROFILE_OFFSET_MAX_DB,

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -215,23 +215,18 @@ _Static_assert(sizeof(uint32_t) == 4, "uint32_t must be exactly 32 bits");
 #define HPSS_SLIDING_ITERATIONS 3U
 #define HPSS_SLIDING_SMOOTH_FACTOR 0.50F
 #define HPSS_BASS_CUTOFF_BINS 24.0F
+#define HPSS_NOISE_FLOOR_GATE_MULTIPLIER 1.15F
+#define HPSS_RATIO_DENOMINATOR_FLOOR 1e-8F
 #define HPSS_TRANSIENT_MARGIN_FACTOR 1.30F
-#define HPSS_TRANSIENT_MARGIN_MIN 1.05F
-#define HPSS_TRANSIENT_MARGIN_MAX 1.65F
 #define HPSS_TRANSIENT_ENERGY_RATIO_THRESHOLD 0.25F
-#define HPSS_SENSITIVITY_DEFAULT 0.50F
-#define HPSS_RATIO_THRESHOLD_MIN 0.08F
-#define HPSS_RATIO_THRESHOLD_MAX 0.60F
 
 /* --------------------------------------------------------------- */
 /* ------------------- 1D Denoiser configurations ---------------- */
 #define GAIN_SMOOTHING_MIN_RELEASE_SEC (0.010F)
 #define GAIN_SMOOTHING_MAX_RELEASE_SEC (0.150F)
 
-// HPSS configurations (Defaults to 0 = HPSS_QUALITY_OFF / zero latency)
-#define HPSS_QUALITY_MODE_1D_DEFAULT 0
-#define HPSS_TIME_WINDOW_1D_DEFAULT HPSS_TIME_WINDOW_LOW
-#define HPSS_FREQ_WINDOW_1D_DEFAULT HPSS_FREQ_WINDOW_LOW
+// HPSS configurations (Defaults to enabled)
+#define HPSS_ENABLE_1D_DEFAULT 1
 
 // STFT configurations
 #define OVERLAP_FACTOR_1D 4
@@ -256,10 +251,8 @@ _Static_assert(sizeof(uint32_t) == 4, "uint32_t must be exactly 32 bits");
 /* ------------------- 2D Denoiser configurations ------------------- */
 /* ------------------------------------------------------------------ */
 
-// HPSS configurations (Defaults to 0 = HPSS_QUALITY_OFF / zero latency)
-#define HPSS_QUALITY_MODE_2D_DEFAULT 0
-#define HPSS_TIME_WINDOW_2D_DEFAULT HPSS_TIME_WINDOW_HIGH
-#define HPSS_FREQ_WINDOW_2D_DEFAULT HPSS_FREQ_WINDOW_HIGH
+// HPSS configurations (Defaults to enabled)
+#define HPSS_ENABLE_2D_DEFAULT 1
 
 // STFT configurations
 #define OVERLAP_FACTOR_2D 4

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -212,16 +212,16 @@ _Static_assert(sizeof(uint32_t) == 4, "uint32_t must be exactly 32 bits");
 // Using power-of-two (64U) for efficient modulo wrap-around and future headroom
 #define DELAY_BUFFER_FRAMES 64U
 
-#define HPSS_TIME_WINDOW_LOW 9U
-#define HPSS_TIME_WINDOW_MEDIUM 17U
-#define HPSS_TIME_WINDOW_HIGH 33U
-#define HPSS_TIME_WINDOW_MAX HPSS_TIME_WINDOW_HIGH
-
-#define HPSS_FREQ_WINDOW_LOW 9U
-#define HPSS_FREQ_WINDOW_MEDIUM 17U
-#define HPSS_FREQ_WINDOW_HIGH 33U
-
+#define HPSS_SLIDING_ITERATIONS 3U
+#define HPSS_SLIDING_SMOOTH_FACTOR 0.50F
 #define HPSS_BASS_CUTOFF_BINS 24.0F
+#define HPSS_TRANSIENT_MARGIN_FACTOR 1.30F
+#define HPSS_TRANSIENT_MARGIN_MIN 1.05F
+#define HPSS_TRANSIENT_MARGIN_MAX 1.65F
+#define HPSS_TRANSIENT_ENERGY_RATIO_THRESHOLD 0.25F
+#define HPSS_SENSITIVITY_DEFAULT 0.50F
+#define HPSS_RATIO_THRESHOLD_MIN 0.08F
+#define HPSS_RATIO_THRESHOLD_MAX 0.60F
 
 /* --------------------------------------------------------------- */
 /* ------------------- 1D Denoiser configurations ---------------- */

--- a/src/shared/denoiser_logic/processing/hpss_filter.c
+++ b/src/shared/denoiser_logic/processing/hpss_filter.c
@@ -103,9 +103,11 @@ void hpss_filter_set_sensitivity(HpssFilter* self, float sensitivity) {
 
   // Invert mapping: higher sensitivity -> lower detection thresholds
   self->energy_ratio_threshold =
-      HPSS_RATIO_THRESHOLD_MAX - s * (HPSS_RATIO_THRESHOLD_MAX - HPSS_RATIO_THRESHOLD_MIN);
+      HPSS_RATIO_THRESHOLD_MAX -
+      s * (HPSS_RATIO_THRESHOLD_MAX - HPSS_RATIO_THRESHOLD_MIN);
   self->margin_factor =
-      HPSS_TRANSIENT_MARGIN_MAX - s * (HPSS_TRANSIENT_MARGIN_MAX - HPSS_TRANSIENT_MARGIN_MIN);
+      HPSS_TRANSIENT_MARGIN_MAX -
+      s * (HPSS_TRANSIENT_MARGIN_MAX - HPSS_TRANSIENT_MARGIN_MIN);
 }
 
 uint32_t hpss_filter_get_latency_frames(const HpssFilter* self) {
@@ -167,7 +169,8 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
 
   // 2. Sliding HPSS Iterations (Ono / Tachibana ISMIR 2008)
   // Harmonic continuity: H_{t,k} aligns with H_{t-1,k} (temporal continuity)
-  // Percussive continuity: P_{t,k} aligns with (P_{t,k-1} + P_{t,k+1})/2 (frequency continuity)
+  // Percussive continuity: P_{t,k} aligns with (P_{t,k-1} + P_{t,k+1})/2
+  // (frequency continuity)
   for (uint32_t iter = 0U; iter < HPSS_SLIDING_ITERATIONS; ++iter) {
     for (uint32_t k = 0U; k < spectrum_size; ++k) {
       float mag = current_magnitude[k];
@@ -210,7 +213,8 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
     // Margin test against horizontal sustain
     float p_diff = p_val - (current_margin * h_val);
 
-    // If noise floor is provided, ensure percussive energy also emerges above noise floor
+    // If noise floor is provided, ensure percussive energy also emerges above
+    // noise floor
     if (noise_floor != NULL && p_diff > 0.0f) {
       float noise_level = noise_floor[k];
       if (p_val < 1.15f * noise_level) {

--- a/src/shared/denoiser_logic/processing/hpss_filter.c
+++ b/src/shared/denoiser_logic/processing/hpss_filter.c
@@ -108,7 +108,7 @@ bool hpss_filter_is_transient_detected(const HpssFilter* self) {
 }
 
 bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
-                         const float* noise_floor, float* delayed_magnitude_out,
+                         const float* noise_floor, float* current_magnitude_out,
                          float* mask_harmonic_out, float* mask_percussive_out) {
   if (!self || !current_magnitude) {
     return false;
@@ -116,8 +116,8 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
 
   const uint32_t spectrum_size = self->config.real_spectrum_size;
 
-  if (delayed_magnitude_out) {
-    memcpy(delayed_magnitude_out, current_magnitude,
+  if (current_magnitude_out) {
+    memcpy(current_magnitude_out, current_magnitude,
            spectrum_size * sizeof(float));
   }
 
@@ -239,15 +239,15 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
     }
 
     // Update state for next frame with exponential temporal tracking
-    self->prev_h[k] = HPSS_SLIDING_SMOOTH_FACTOR * (self->prev_h[k] + self->h[k]);
+    self->prev_h[k] =
+        HPSS_SLIDING_SMOOTH_FACTOR * (self->prev_h[k] + self->h[k]);
   }
 
   sb_simd_restore_state(simd_state);
 
-  self->percussive_ratio =
-      (total_mag_sq > HPSS_RATIO_DENOMINATOR_FLOOR)
-          ? (percussive_mag_sq / total_mag_sq)
-          : 0.0f;
+  self->percussive_ratio = (total_mag_sq > HPSS_RATIO_DENOMINATOR_FLOOR)
+                               ? (percussive_mag_sq / total_mag_sq)
+                               : 0.0f;
 
   self->is_transient_detected =
       (self->percussive_ratio >= self->energy_ratio_threshold);

--- a/src/shared/denoiser_logic/processing/hpss_filter.c
+++ b/src/shared/denoiser_logic/processing/hpss_filter.c
@@ -20,13 +20,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "hpss_filter.h"
 #include "shared/configurations.h"
+#include "shared/utils/simd_utils.h"
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 struct HpssFilter {
   HpssConfig config;
-  bool is_active;
+  bool is_enabled;
   bool is_initialized;
 
   float* prev_h; // Previous frame harmonic magnitude estimate H_{t-1, k}
@@ -50,7 +51,7 @@ HpssFilter* hpss_filter_initialize(HpssConfig config) {
   }
 
   self->config = config;
-  self->is_active = true;
+  self->is_enabled = true;
   self->is_initialized = false;
   self->energy_ratio_threshold = HPSS_TRANSIENT_ENERGY_RATIO_THRESHOLD;
   self->margin_factor = HPSS_TRANSIENT_MARGIN_FACTOR;
@@ -86,28 +87,11 @@ void hpss_filter_free(HpssFilter* self) {
   free(self);
 }
 
-void hpss_filter_set_quality_mode(HpssFilter* self, HpssQualityMode mode) {
+void hpss_filter_set_enabled(HpssFilter* self, bool enabled) {
   if (!self) {
     return;
   }
-  self->is_active = (mode != HPSS_QUALITY_OFF);
-}
-
-void hpss_filter_set_sensitivity(HpssFilter* self, float sensitivity) {
-  if (!self) {
-    return;
-  }
-
-  // Clamp sensitivity to [0.0, 1.0]
-  float s = fmaxf(0.0f, fminf(1.0f, sensitivity));
-
-  // Invert mapping: higher sensitivity -> lower detection thresholds
-  self->energy_ratio_threshold =
-      HPSS_RATIO_THRESHOLD_MAX -
-      s * (HPSS_RATIO_THRESHOLD_MAX - HPSS_RATIO_THRESHOLD_MIN);
-  self->margin_factor =
-      HPSS_TRANSIENT_MARGIN_MAX -
-      s * (HPSS_TRANSIENT_MARGIN_MAX - HPSS_TRANSIENT_MARGIN_MIN);
+  self->is_enabled = enabled;
 }
 
 uint32_t hpss_filter_get_latency_frames(const HpssFilter* self) {
@@ -120,7 +104,7 @@ float hpss_filter_get_onset_ratio(const HpssFilter* self) {
 }
 
 bool hpss_filter_is_transient_detected(const HpssFilter* self) {
-  return (self && self->is_active) ? self->is_transient_detected : false;
+  return (self && self->is_enabled) ? self->is_transient_detected : false;
 }
 
 bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
@@ -137,7 +121,7 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
            spectrum_size * sizeof(float));
   }
 
-  if (!self->is_active) {
+  if (!self->is_enabled) {
     if (mask_harmonic_out) {
       for (uint32_t k = 0U; k < spectrum_size; ++k) {
         mask_harmonic_out[k] = 1.0f;
@@ -160,11 +144,13 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
     self->is_initialized = true;
   }
 
+  sb_simd_state_t simd_state = sb_simd_enable_ftz_daz();
+
   // 1. Initialize H and P for current frame
   for (uint32_t k = 0U; k < spectrum_size; ++k) {
     float mag = current_magnitude[k];
-    self->h[k] = 0.5f * mag;
-    self->p[k] = 0.5f * mag;
+    self->h[k] = HPSS_SLIDING_SMOOTH_FACTOR * mag;
+    self->p[k] = HPSS_SLIDING_SMOOTH_FACTOR * mag;
   }
 
   // 2. Sliding HPSS Iterations (Ono / Tachibana ISMIR 2008)
@@ -186,14 +172,15 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
       // Percussive reference from adjacent frequency bins
       float p_prev = (k > 0U) ? self->p[k - 1U] : self->p[k];
       float p_next = (k + 1U < spectrum_size) ? self->p[k + 1U] : self->p[k];
-      float p_ref = 0.5f * (p_prev + p_next);
+      float p_ref = HPSS_SLIDING_SMOOTH_FACTOR * (p_prev + p_next);
 
       // Auxiliary function update
       float h_sq = h_ref * h_ref;
       float p_sq = p_ref * p_ref;
       float denom = h_sq + p_sq;
 
-      float w_h = (denom > SPECTRAL_EPSILON) ? (h_sq / denom) : 0.5f;
+      float w_h = (denom > SPECTRAL_EPSILON) ? (h_sq / denom)
+                                             : HPSS_SLIDING_SMOOTH_FACTOR;
       float w_p = 1.0f - w_h;
 
       self->h[k] = w_h * mag;
@@ -217,7 +204,7 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
     // noise floor
     if (noise_floor != NULL && p_diff > 0.0f) {
       float noise_level = noise_floor[k];
-      if (p_val < 1.15f * noise_level) {
+      if (p_val < HPSS_NOISE_FLOOR_GATE_MULTIPLIER * noise_level) {
         p_diff = 0.0f; // Sub-noise fluctuation: treat as stationary noise
       }
     }
@@ -252,11 +239,15 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
     }
 
     // Update state for next frame with exponential temporal tracking
-    self->prev_h[k] = 0.5f * (self->prev_h[k] + current_magnitude[k]);
+    self->prev_h[k] = HPSS_SLIDING_SMOOTH_FACTOR * (self->prev_h[k] + self->h[k]);
   }
 
+  sb_simd_restore_state(simd_state);
+
   self->percussive_ratio =
-      (total_mag_sq > 1e-8f) ? (percussive_mag_sq / total_mag_sq) : 0.0f;
+      (total_mag_sq > HPSS_RATIO_DENOMINATOR_FLOOR)
+          ? (percussive_mag_sq / total_mag_sq)
+          : 0.0f;
 
   self->is_transient_detected =
       (self->percussive_ratio >= self->energy_ratio_threshold);

--- a/src/shared/denoiser_logic/processing/hpss_filter.c
+++ b/src/shared/denoiser_logic/processing/hpss_filter.c
@@ -20,110 +20,28 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "hpss_filter.h"
 #include "shared/configurations.h"
-#include "shared/utils/spectral_circular_buffer.h"
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
 struct HpssFilter {
   HpssConfig config;
-  uint32_t latency_frames;
-  SbSpectralCircularBuffer* circular_buffer;
-  uint32_t mag_layer_id;
+  bool is_active;
+  bool is_initialized;
 
-  float* prev_mag;
-  float* m_h;
-  float* m_p;
-  float* time_sort_buffer;
-  float* onset_boost_buffer;
-  float* onset_ratio_buffer;
+  float* prev_h; // Previous frame harmonic magnitude estimate H_{t-1, k}
+  float* h;      // Current frame harmonic magnitude estimate H_{t, k}
+  float* p;      // Current frame percussive magnitude estimate P_{t, k}
 
-  uint32_t write_pos;
-  float delayed_onset_ratio;
-  bool is_initialized_flux;
+  float percussive_ratio;
+  float energy_ratio_threshold;
+  float margin_factor;
+  bool is_transient_detected;
 };
 
-static float fast_median(float* arr, uint32_t n) {
-  for (uint32_t i = 1U; i < n; ++i) {
-    float key = arr[i];
-    int32_t j = (int32_t)i - 1;
-    while (j >= 0 && arr[j] > key) {
-      arr[j + 1] = arr[j];
-      j--;
-    }
-    arr[j + 1] = key;
-  }
-  if (n % 2U == 1U) {
-    return arr[n / 2U];
-  }
-  return 0.5f * (arr[(n / 2U) - 1U] + arr[n / 2U]);
-}
-
-static void compute_adaptive_freq_median(const float* src, float* dst,
-                                         int num_bins, int max_win_size) {
-  int max_half = max_win_size / 2;
-  if (max_half > 31) {
-    max_half = 31;
-  }
-  float scratch[64];
-
-  for (int k = 0; k < num_bins; k++) {
-    // Scale half-window size: 1 bin at bass, scaling up to max_half at high
-    // frequencies
-    int half_win = k / ((int)HPSS_BASS_CUTOFF_BINS / 2);
-    if (half_win < 1) {
-      half_win = 1; // 3-bin window for bass (k-1, k, k+1)
-    }
-    if (half_win > max_half) {
-      half_win = max_half; // Cap at max_half (e.g. 8 for 17-bin)
-    }
-
-    int start_idx = k - half_win;
-    if (start_idx < 0) {
-      start_idx = 0;
-    }
-
-    int end_idx = k + half_win;
-    if (end_idx >= num_bins) {
-      end_idx = num_bins - 1;
-    }
-
-    int count = end_idx - start_idx + 1;
-
-    for (int i = 0; i < count; i++) {
-      scratch[i] = src[start_idx + i];
-    }
-
-    // Fast insertion sort for small array
-    for (int i = 1; i < count; i++) {
-      float key = scratch[i];
-      int j = i - 1;
-      while (j >= 0 && scratch[j] > key) {
-        scratch[j + 1] = scratch[j];
-        j--;
-      }
-      scratch[j + 1] = key;
-    }
-
-    dst[k] = scratch[count / 2];
-  }
-}
-
 HpssFilter* hpss_filter_initialize(HpssConfig config) {
-  if (config.real_spectrum_size == 0U || config.time_window_size == 0U ||
-      config.freq_window_size == 0U) {
+  if (config.real_spectrum_size == 0U) {
     return NULL;
-  }
-
-  // Enforce odd window sizes
-  if (config.time_window_size % 2U == 0U) {
-    config.time_window_size += 1U;
-  }
-  if (config.time_window_size > HPSS_TIME_WINDOW_MAX) {
-    config.time_window_size = HPSS_TIME_WINDOW_MAX;
-  }
-  if (config.freq_window_size % 2U == 0U) {
-    config.freq_window_size += 1U;
   }
 
   HpssFilter* self = (HpssFilter*)calloc(1U, sizeof(HpssFilter));
@@ -132,44 +50,20 @@ HpssFilter* hpss_filter_initialize(HpssConfig config) {
   }
 
   self->config = config;
-  self->latency_frames = (config.time_window_size - 1U) / 2U;
-  self->write_pos = 0U;
-  self->delayed_onset_ratio = 0.0f;
-  self->is_initialized_flux = false;
+  self->is_active = true;
+  self->is_initialized = false;
+  self->energy_ratio_threshold = HPSS_TRANSIENT_ENERGY_RATIO_THRESHOLD;
+  self->margin_factor = HPSS_TRANSIENT_MARGIN_FACTOR;
+  self->percussive_ratio = 0.0f;
+  self->is_transient_detected = false;
 
-  // Pre-allocate circular buffer to maximum window size
-  self->circular_buffer = spectral_circular_buffer_create(HPSS_TIME_WINDOW_MAX);
-  if (!self->circular_buffer) {
+  self->prev_h = (float*)calloc(config.real_spectrum_size, sizeof(float));
+  self->h = (float*)calloc(config.real_spectrum_size, sizeof(float));
+  self->p = (float*)calloc(config.real_spectrum_size, sizeof(float));
+
+  if (!self->prev_h || !self->h || !self->p) {
     hpss_filter_free(self);
     return NULL;
-  }
-
-  self->mag_layer_id = spectral_circular_buffer_add_layer(
-      self->circular_buffer, config.real_spectrum_size);
-
-  if (self->mag_layer_id == 0xFFFFFFFFU) {
-    hpss_filter_free(self);
-    return NULL;
-  }
-
-  self->prev_mag = (float*)calloc(config.real_spectrum_size, sizeof(float));
-  self->m_h = (float*)calloc(config.real_spectrum_size, sizeof(float));
-  self->m_p = (float*)calloc(config.real_spectrum_size, sizeof(float));
-  self->time_sort_buffer = (float*)calloc(HPSS_TIME_WINDOW_MAX, sizeof(float));
-  self->onset_boost_buffer =
-      (float*)calloc(HPSS_TIME_WINDOW_MAX, sizeof(float));
-  self->onset_ratio_buffer =
-      (float*)calloc(HPSS_TIME_WINDOW_MAX, sizeof(float));
-
-  if (!self->prev_mag || !self->m_h || !self->m_p || !self->time_sort_buffer ||
-      !self->onset_boost_buffer || !self->onset_ratio_buffer) {
-    hpss_filter_free(self);
-    return NULL;
-  }
-
-  for (uint32_t i = 0U; i < HPSS_TIME_WINDOW_MAX; ++i) {
-    self->onset_boost_buffer[i] = 0.0f;
-    self->onset_ratio_buffer[i] = 0.0f;
   }
 
   return self;
@@ -180,26 +74,14 @@ void hpss_filter_free(HpssFilter* self) {
     return;
   }
 
-  if (self->circular_buffer) {
-    spectral_circular_buffer_free(self->circular_buffer);
+  if (self->prev_h) {
+    free(self->prev_h);
   }
-  if (self->prev_mag) {
-    free(self->prev_mag);
+  if (self->h) {
+    free(self->h);
   }
-  if (self->m_h) {
-    free(self->m_h);
-  }
-  if (self->m_p) {
-    free(self->m_p);
-  }
-  if (self->time_sort_buffer) {
-    free(self->time_sort_buffer);
-  }
-  if (self->onset_boost_buffer) {
-    free(self->onset_boost_buffer);
-  }
-  if (self->onset_ratio_buffer) {
-    free(self->onset_ratio_buffer);
+  if (self->p) {
+    free(self->p);
   }
   free(self);
 }
@@ -208,119 +90,52 @@ void hpss_filter_set_quality_mode(HpssFilter* self, HpssQualityMode mode) {
   if (!self) {
     return;
   }
+  self->is_active = (mode != HPSS_QUALITY_OFF);
+}
 
-  uint32_t new_time_win = HPSS_TIME_WINDOW_MEDIUM;
-  uint32_t new_freq_win = HPSS_FREQ_WINDOW_MEDIUM;
-  switch (mode) {
-    case HPSS_QUALITY_OFF:
-      new_time_win = 0U;
-      new_freq_win = 0U;
-      break;
-    case HPSS_QUALITY_LOW:
-      new_time_win = HPSS_TIME_WINDOW_LOW;
-      new_freq_win = HPSS_FREQ_WINDOW_LOW;
-      break;
-    case HPSS_QUALITY_MEDIUM:
-      new_time_win = HPSS_TIME_WINDOW_MEDIUM;
-      new_freq_win = HPSS_FREQ_WINDOW_MEDIUM;
-      break;
-    case HPSS_QUALITY_HIGH:
-      new_time_win = HPSS_TIME_WINDOW_HIGH;
-      new_freq_win = HPSS_FREQ_WINDOW_HIGH;
-      break;
-    default:
-      new_time_win = HPSS_TIME_WINDOW_MEDIUM;
-      new_freq_win = HPSS_FREQ_WINDOW_MEDIUM;
-      break;
-  }
-
-  if (self->config.time_window_size == new_time_win &&
-      self->config.freq_window_size == new_freq_win) {
+void hpss_filter_set_sensitivity(HpssFilter* self, float sensitivity) {
+  if (!self) {
     return;
   }
 
-  if (new_time_win > self->config.time_window_size) {
-    spectral_circular_buffer_clear(self->circular_buffer);
-    self->is_initialized_flux = false;
-  }
+  // Clamp sensitivity to [0.0, 1.0]
+  float s = fmaxf(0.0f, fminf(1.0f, sensitivity));
 
-  self->config.time_window_size = new_time_win;
-  self->config.freq_window_size = new_freq_win;
-  self->latency_frames = (new_time_win > 0U) ? ((new_time_win - 1U) / 2U) : 0U;
+  // Invert mapping: higher sensitivity -> lower detection thresholds
+  self->energy_ratio_threshold =
+      HPSS_RATIO_THRESHOLD_MAX - s * (HPSS_RATIO_THRESHOLD_MAX - HPSS_RATIO_THRESHOLD_MIN);
+  self->margin_factor =
+      HPSS_TRANSIENT_MARGIN_MAX - s * (HPSS_TRANSIENT_MARGIN_MAX - HPSS_TRANSIENT_MARGIN_MIN);
 }
 
 uint32_t hpss_filter_get_latency_frames(const HpssFilter* self) {
-  return self ? self->latency_frames : 0U;
+  (void)self;
+  return 0U; // Sliding HPSS is strictly causal with zero lookahead frames
 }
 
 float hpss_filter_get_onset_ratio(const HpssFilter* self) {
-  return self ? self->delayed_onset_ratio : 0.0f;
+  return self ? self->percussive_ratio : 0.0f;
+}
+
+bool hpss_filter_is_transient_detected(const HpssFilter* self) {
+  return (self && self->is_active) ? self->is_transient_detected : false;
 }
 
 bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
-                         float* delayed_magnitude_out, float* mask_harmonic_out,
-                         float* mask_percussive_out) {
+                         const float* noise_floor, float* delayed_magnitude_out,
+                         float* mask_harmonic_out, float* mask_percussive_out) {
   if (!self || !current_magnitude) {
     return false;
   }
 
   const uint32_t spectrum_size = self->config.real_spectrum_size;
 
-  const uint32_t time_win = self->config.time_window_size;
-  const uint32_t freq_win = self->config.freq_window_size;
-
-  // 1. Multi-band Onset / Spectral Flux Detection (Preserves high-frequency
-  // plucks & attacks)
-  float onset_ratio = 0.0f;
-  float boost_add = 0.0f;
-  if (self->is_initialized_flux) {
-    // Subband flux across 4 frequency regions (Low, Mid-Low, Mid-High, High)
-    const uint32_t bounds[5] = {0U, spectrum_size / 8U, spectrum_size / 4U,
-                                spectrum_size / 2U, spectrum_size};
-    float max_subband_ratio = 0.0f;
-
-    for (int b = 0; b < 4; ++b) {
-      uint32_t start_k = bounds[b];
-      uint32_t end_k = bounds[b + 1];
-      float sub_flux = 0.0f;
-      float sub_prev_sum = 0.0f;
-
-      for (uint32_t k = start_k; k < end_k; ++k) {
-        float diff = current_magnitude[k] - self->prev_mag[k];
-        if (diff > 0.0f) {
-          sub_flux += diff;
-        }
-        sub_prev_sum += self->prev_mag[k];
-      }
-      float sub_ratio = sub_flux / (sub_prev_sum + 1e-6f);
-      if (sub_ratio > max_subband_ratio) {
-        max_subband_ratio = sub_ratio;
-      }
-    }
-
-    onset_ratio = max_subband_ratio;
-    boost_add = 3.0f * onset_ratio;
-    if (boost_add > 3.0f) {
-      boost_add = 3.0f;
-    } else if (boost_add < 0.0f) {
-      boost_add = 0.0f;
-    }
-  } else {
-    self->is_initialized_flux = true;
+  if (delayed_magnitude_out) {
+    memcpy(delayed_magnitude_out, current_magnitude,
+           spectrum_size * sizeof(float));
   }
-  memcpy(self->prev_mag, current_magnitude, spectrum_size * sizeof(float));
-  self->onset_boost_buffer[self->write_pos] = boost_add;
-  self->onset_ratio_buffer[self->write_pos] = onset_ratio;
 
-  // 2. Push magnitude frames into circular buffer
-  spectral_circular_buffer_push(self->circular_buffer, self->mag_layer_id,
-                                current_magnitude);
-
-  if (self->config.time_window_size == 0U || self->latency_frames == 0U) {
-    if (delayed_magnitude_out) {
-      memcpy(delayed_magnitude_out, current_magnitude,
-             spectrum_size * sizeof(float));
-    }
+  if (!self->is_active) {
     if (mask_harmonic_out) {
       for (uint32_t k = 0U; k < spectrum_size; ++k) {
         mask_harmonic_out[k] = 1.0f;
@@ -329,68 +144,93 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
     if (mask_percussive_out) {
       memset(mask_percussive_out, 0, spectrum_size * sizeof(float));
     }
-    self->delayed_onset_ratio = 0.0f;
-    self->write_pos = (self->write_pos + 1U) % HPSS_TIME_WINDOW_MAX;
-    spectral_circular_buffer_advance(self->circular_buffer);
+    self->percussive_ratio = 0.0f;
+    self->is_transient_detected = false;
     return true;
   }
 
-  // 3. Retrieve delayed frame
-  const float* delayed_mag = spectral_circular_buffer_retrieve(
-      self->circular_buffer, self->mag_layer_id, self->latency_frames);
-
-  if (!delayed_mag) {
-    return false;
-  }
-
-  if (delayed_magnitude_out) {
-    memcpy(delayed_magnitude_out, delayed_mag, spectrum_size * sizeof(float));
-  }
-
-  uint32_t delayed_idx =
-      (self->write_pos + HPSS_TIME_WINDOW_MAX - self->latency_frames) %
-      HPSS_TIME_WINDOW_MAX;
-  float frame_onset_boost = self->onset_boost_buffer[delayed_idx];
-  self->delayed_onset_ratio = self->onset_ratio_buffer[delayed_idx];
-
-  // 4. Median Filtering
-  // 4a. Harmonic median (M_H) along time axis for each frequency bin
-  const float* frames[HPSS_TIME_WINDOW_MAX];
-  for (uint32_t t = 0U; t < time_win; ++t) {
-    frames[t] = spectral_circular_buffer_retrieve(self->circular_buffer,
-                                                  self->mag_layer_id, t);
-  }
-
-  for (uint32_t k = 0U; k < spectrum_size; ++k) {
-    for (uint32_t t = 0U; t < time_win; ++t) {
-      self->time_sort_buffer[t] = frames[t] ? frames[t][k] : 0.0f;
+  if (!self->is_initialized) {
+    for (uint32_t k = 0U; k < spectrum_size; ++k) {
+      self->prev_h[k] = current_magnitude[k];
+      self->h[k] = current_magnitude[k];
+      self->p[k] = 0.0f;
     }
-    self->m_h[k] = fast_median(self->time_sort_buffer, time_win);
+    self->is_initialized = true;
   }
 
-  // 4b. Percussive median (M_P) along frequency axis for delayed frame
-  compute_adaptive_freq_median(delayed_mag, self->m_p, (int)spectrum_size,
-                               (int)freq_win);
-
-  // 5. Onset-Boosted Soft Masking with Transient Excess Margin
-  // In stationary noise (M_P ~= M_H), excess is zero -> 100% smoothed harmonic
-  // path G_H to eliminate musical noise
+  // 1. Initialize H and P for current frame
   for (uint32_t k = 0U; k < spectrum_size; ++k) {
-    float m_h = self->m_h[k];
-    float m_p_boosted = self->m_p[k] * (1.0f + frame_onset_boost);
+    float mag = current_magnitude[k];
+    self->h[k] = 0.5f * mag;
+    self->p[k] = 0.5f * mag;
+  }
 
-    float p_diff = m_p_boosted - m_h;
-    float p_excess = (p_diff > 0.0f) ? p_diff : 0.0f;
+  // 2. Sliding HPSS Iterations (Ono / Tachibana ISMIR 2008)
+  // Harmonic continuity: H_{t,k} aligns with H_{t-1,k} (temporal continuity)
+  // Percussive continuity: P_{t,k} aligns with (P_{t,k-1} + P_{t,k+1})/2 (frequency continuity)
+  for (uint32_t iter = 0U; iter < HPSS_SLIDING_ITERATIONS; ++iter) {
+    for (uint32_t k = 0U; k < spectrum_size; ++k) {
+      float mag = current_magnitude[k];
+      if (mag <= SPECTRAL_EPSILON) {
+        self->h[k] = 0.0f;
+        self->p[k] = 0.0f;
+        continue;
+      }
 
-    float m_h_sq = m_h * m_h;
+      // Harmonic reference from previous frame
+      float h_ref = self->prev_h[k];
+
+      // Percussive reference from adjacent frequency bins
+      float p_prev = (k > 0U) ? self->p[k - 1U] : self->p[k];
+      float p_next = (k + 1U < spectrum_size) ? self->p[k + 1U] : self->p[k];
+      float p_ref = 0.5f * (p_prev + p_next);
+
+      // Auxiliary function update
+      float h_sq = h_ref * h_ref;
+      float p_sq = p_ref * p_ref;
+      float denom = h_sq + p_sq;
+
+      float w_h = (denom > SPECTRAL_EPSILON) ? (h_sq / denom) : 0.5f;
+      float w_p = 1.0f - w_h;
+
+      self->h[k] = w_h * mag;
+      self->p[k] = w_p * mag;
+    }
+  }
+
+  // 3. Compute Soft Masks with Noise Floor Adaptive Gating & Excess Margin
+  float total_mag_sq = 0.0f;
+  float percussive_mag_sq = 0.0f;
+  const float current_margin = self->margin_factor;
+
+  for (uint32_t k = 0U; k < spectrum_size; ++k) {
+    float h_val = self->h[k];
+    float p_val = self->p[k];
+
+    // Margin test against horizontal sustain
+    float p_diff = p_val - (current_margin * h_val);
+
+    // If noise floor is provided, ensure percussive energy also emerges above noise floor
+    if (noise_floor != NULL && p_diff > 0.0f) {
+      float noise_level = noise_floor[k];
+      if (p_val < 1.15f * noise_level) {
+        p_diff = 0.0f; // Sub-noise fluctuation: treat as stationary noise
+      }
+    }
+
+    float p_excess =
+        (k >= (uint32_t)HPSS_BASS_CUTOFF_BINS && p_diff > 0.0f) ? p_diff : 0.0f;
+
+    float h_sq = h_val * h_val;
     float p_excess_sq = p_excess * p_excess;
-    float sum_sq = m_h_sq + p_excess_sq;
+    float sum_sq = h_sq + p_excess_sq;
 
     float w_p = 0.0f;
     float w_h = 1.0f;
     if (sum_sq > SPECTRAL_EPSILON) {
-      float inv_sum_sq = 1.0f / sum_sq;
-      w_p = p_excess_sq * inv_sum_sq;
+      float raw_w_p = p_excess_sq / sum_sq;
+      // Apply smooth power compression to prevent pre-echo ghosting
+      w_p = raw_w_p * raw_w_p;
       w_h = 1.0f - w_p;
     }
 
@@ -400,11 +240,22 @@ bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
     if (mask_percussive_out) {
       mask_percussive_out[k] = w_p;
     }
+
+    float mag_sq = current_magnitude[k] * current_magnitude[k];
+    if (k >= (uint32_t)HPSS_BASS_CUTOFF_BINS) {
+      total_mag_sq += mag_sq;
+      percussive_mag_sq += w_p * mag_sq;
+    }
+
+    // Update state for next frame with exponential temporal tracking
+    self->prev_h[k] = 0.5f * (self->prev_h[k] + current_magnitude[k]);
   }
 
-  // 6. Advance circular buffer and write position
-  self->write_pos = (self->write_pos + 1U) % HPSS_TIME_WINDOW_MAX;
-  spectral_circular_buffer_advance(self->circular_buffer);
+  self->percussive_ratio =
+      (total_mag_sq > 1e-8f) ? (percussive_mag_sq / total_mag_sq) : 0.0f;
+
+  self->is_transient_detected =
+      (self->percussive_ratio >= self->energy_ratio_threshold);
 
   return true;
 }

--- a/src/shared/denoiser_logic/processing/hpss_filter.h
+++ b/src/shared/denoiser_logic/processing/hpss_filter.h
@@ -28,10 +28,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef HPSS_QUALITY_MODE_DEFINED
 #define HPSS_QUALITY_MODE_DEFINED
 typedef enum HpssQualityMode {
-  HPSS_QUALITY_OFF = 0,    // Bypassed (Lookahead: 0)
-  HPSS_QUALITY_LOW = 1,    // L_time = 9 frames (Lookahead: 4)
-  HPSS_QUALITY_MEDIUM = 2, // L_time = 17 frames (Lookahead: 8)
-  HPSS_QUALITY_HIGH = 3    // L_time = 33 frames (Lookahead: 16)
+  HPSS_QUALITY_OFF = 0,
+  HPSS_QUALITY_LOW = 1,
+  HPSS_QUALITY_MEDIUM = 2,
+  HPSS_QUALITY_HIGH = 3
 } HpssQualityMode;
 #endif
 
@@ -39,23 +39,22 @@ typedef struct HpssFilter HpssFilter;
 
 typedef struct HpssConfig {
   uint32_t real_spectrum_size;
-  uint32_t time_window_size; // Default: 17 frames
-  uint32_t freq_window_size; // Default: 17 bins
 } HpssConfig;
 
-// Pre-allocates ring buffers to HPSS_TIME_WINDOW_MAX
 HpssFilter* hpss_filter_initialize(HpssConfig config);
 void hpss_filter_free(HpssFilter* self);
 
 // Dynamic parameter update (allocator-free)
 void hpss_filter_set_quality_mode(HpssFilter* self, HpssQualityMode mode);
+void hpss_filter_set_sensitivity(HpssFilter* self, float sensitivity);
 
-// Returns current lookahead delay in frames: (current_time_window - 1) / 2
+// Sliding HPSS is causal with 0 lookahead delay frames
 uint32_t hpss_filter_get_latency_frames(const HpssFilter* self);
 float hpss_filter_get_onset_ratio(const HpssFilter* self);
+bool hpss_filter_is_transient_detected(const HpssFilter* self);
 
 bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
-                         float* delayed_magnitude_out, float* mask_harmonic_out,
-                         float* mask_percussive_out);
+                         const float* noise_floor, float* delayed_magnitude_out,
+                         float* mask_harmonic_out, float* mask_percussive_out);
 
 #endif // SHARED_DENOISER_LOGIC_HPSS_FILTER_H

--- a/src/shared/denoiser_logic/processing/hpss_filter.h
+++ b/src/shared/denoiser_logic/processing/hpss_filter.h
@@ -41,9 +41,24 @@ void hpss_filter_set_enabled(HpssFilter* self, bool enabled);
 uint32_t hpss_filter_get_latency_frames(const HpssFilter* self);
 float hpss_filter_get_onset_ratio(const HpssFilter* self);
 bool hpss_filter_is_transient_detected(const HpssFilter* self);
-
+/**
+ * Process a spectral magnitude frame with Sliding HPSS.
+ *
+ * @param self HPSS filter instance
+ * @param current_magnitude Current frame magnitude spectrum
+ * [real_spectrum_size]
+ * @param noise_floor Optional noise floor spectrum (or NULL to skip sub-noise
+ * gate)
+ * @param current_magnitude_out Optional destination for current frame magnitude
+ * copy (or NULL)
+ * @param mask_harmonic_out Optional output array for harmonic soft mask (or
+ * NULL)
+ * @param mask_percussive_out Optional output array for percussive soft mask (or
+ * NULL)
+ * @return true on success, false on invalid arguments
+ */
 bool hpss_filter_process(HpssFilter* self, const float* current_magnitude,
-                         const float* noise_floor, float* delayed_magnitude_out,
+                         const float* noise_floor, float* current_magnitude_out,
                          float* mask_harmonic_out, float* mask_percussive_out);
 
 #endif // SHARED_DENOISER_LOGIC_HPSS_FILTER_H

--- a/src/shared/denoiser_logic/processing/hpss_filter.h
+++ b/src/shared/denoiser_logic/processing/hpss_filter.h
@@ -25,16 +25,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdbool.h>
 #include <stdint.h>
 
-#ifndef HPSS_QUALITY_MODE_DEFINED
-#define HPSS_QUALITY_MODE_DEFINED
-typedef enum HpssQualityMode {
-  HPSS_QUALITY_OFF = 0,
-  HPSS_QUALITY_LOW = 1,
-  HPSS_QUALITY_MEDIUM = 2,
-  HPSS_QUALITY_HIGH = 3
-} HpssQualityMode;
-#endif
-
 typedef struct HpssFilter HpssFilter;
 
 typedef struct HpssConfig {
@@ -45,8 +35,7 @@ HpssFilter* hpss_filter_initialize(HpssConfig config);
 void hpss_filter_free(HpssFilter* self);
 
 // Dynamic parameter update (allocator-free)
-void hpss_filter_set_quality_mode(HpssFilter* self, HpssQualityMode mode);
-void hpss_filter_set_sensitivity(HpssFilter* self, float sensitivity);
+void hpss_filter_set_enabled(HpssFilter* self, bool enabled);
 
 // Sliding HPSS is causal with 0 lookahead delay frames
 uint32_t hpss_filter_get_latency_frames(const HpssFilter* self);

--- a/src/shared/utils/spectral_utils.c
+++ b/src/shared/utils/spectral_utils.c
@@ -292,21 +292,3 @@ bool get_morphed_profile(float* output_profile, const float* mean_profile,
 
   return true;
 }
-
-void apply_onset_alpha_ducking(float* alpha, uint32_t num_bins,
-                               float onset_ratio) {
-  if (!alpha || onset_ratio <= 0.01f || num_bins == 0U) {
-    return;
-  }
-
-  float reduction = onset_ratio * 2.0f;
-  if (reduction > 1.0f) {
-    reduction = 1.0f;
-  }
-
-  for (uint32_t k = 0U; k < num_bins; k++) {
-    // Duck alpha down toward 1.0 (no over-subtraction) on attack frame across
-    // full spectrum
-    alpha[k] = 1.0f + ((alpha[k] - 1.0f) * (1.0f - reduction));
-  }
-}

--- a/src/shared/utils/spectral_utils.h
+++ b/src/shared/utils/spectral_utils.h
@@ -71,8 +71,6 @@ bool get_morphed_profile(float* output_profile, const float* mean_profile,
                          const float* median_profile, const float* max_profile,
                          const float* min_profile, uint32_t size,
                          float aggressiveness);
-void apply_onset_alpha_ducking(float* alpha, uint32_t num_bins,
-                               float onset_ratio);
 
 #include "shared/utils/general_utils.h"
 

--- a/tests/test_audio_file_regression.c
+++ b/tests/test_audio_file_regression.c
@@ -33,7 +33,7 @@ static const SpectralBleachDenoiserParameters canonical_denoiser_params = {
     .smoothing_factor = 0.0f,
     .whitening_factor = 50.0f,
     .masking_depth = 0.5f,
-    .hpss_quality_mode = HPSS_QUALITY_LOW};
+    .hpss_enable = 1};
 
 static const SpectralBleachDenoiserParameters canonical_adenoiser_params = {
     .residual_listen = false,
@@ -41,7 +41,7 @@ static const SpectralBleachDenoiserParameters canonical_adenoiser_params = {
     .smoothing_factor = 0.0f,
     .whitening_factor = 50.0f,
     .masking_depth = 0.5f,
-    .hpss_quality_mode = HPSS_QUALITY_LOW,
+    .hpss_enable = 1,
 
     .adaptive_noise = 1,
     .noise_estimation_method = 0};

--- a/tests/test_hpss_filter.c
+++ b/tests/test_hpss_filter.c
@@ -138,10 +138,13 @@ void test_hpss_filter(void) {
     bool ok = hpss_filter_process(filter, current_mag, NULL, delayed_mag,
                                   mask_h, mask_p);
     TEST_ASSERT(ok, "Process on disabled filter should succeed");
-    TEST_ASSERT(delayed_mag[10] == current_mag[10],
-                "Delayed magnitude should match current magnitude when disabled");
-    TEST_ASSERT(mask_h[10] == 1.0f, "Harmonic mask should be 1.0 when disabled");
-    TEST_ASSERT(mask_p[10] == 0.0f, "Percussive mask should be 0.0 when disabled");
+    TEST_ASSERT(
+        delayed_mag[10] == current_mag[10],
+        "Delayed magnitude should match current magnitude when disabled");
+    TEST_ASSERT(mask_h[10] == 1.0f,
+                "Harmonic mask should be 1.0 when disabled");
+    TEST_ASSERT(mask_p[10] == 0.0f,
+                "Percussive mask should be 0.0 when disabled");
   }
   TEST_ASSERT(!hpss_filter_is_transient_detected(filter),
               "Disabled HPSS should not report transients");

--- a/tests/test_hpss_filter.c
+++ b/tests/test_hpss_filter.c
@@ -247,7 +247,8 @@ void test_hpss_subband_transient_in_noise(void) {
     noise_floor[i] = (i < 40) ? 2.0f : 0.2f;
   }
 
-  // 1. Feed baseline heavy stationary noise (e.g. low-frequency hum/rumble + noise)
+  // 1. Feed baseline heavy stationary noise (e.g. low-frequency hum/rumble +
+  // noise)
   for (uint32_t frame = 0; frame < 30; ++frame) {
     for (uint32_t i = 0; i < 257; ++i) {
       current_mag[i] = (i < 40) ? 2.0f : 0.2f; // Heavy bass noise
@@ -258,7 +259,8 @@ void test_hpss_subband_transient_in_noise(void) {
   TEST_ASSERT(!hpss_filter_is_transient_detected(filter),
               "Baseline noise with heavy rumble should be harmonic");
 
-  // 2. Inject high-frequency localized transient (e.g. snare/hat/pluck attack in bins 80-160)
+  // 2. Inject high-frequency localized transient (e.g. snare/hat/pluck attack
+  // in bins 80-160)
   for (uint32_t i = 0; i < 257; ++i) {
     current_mag[i] = (i < 40) ? 2.0f : 0.2f;
     if (i >= 80 && i <= 160) {

--- a/tests/test_hpss_filter.c
+++ b/tests/test_hpss_filter.c
@@ -43,8 +43,6 @@ void test_hpss_filter(void) {
   // 1. Invalid Initialization
   HpssConfig invalid_cfg = {
       .real_spectrum_size = 0U,
-      .time_window_size = 17U,
-      .freq_window_size = 17U,
   };
   HpssFilter* invalid_f = hpss_filter_initialize(invalid_cfg);
   TEST_ASSERT(invalid_f == NULL, "Initialization with size 0 should fail");
@@ -55,15 +53,13 @@ void test_hpss_filter(void) {
   // 3. Valid Initialization
   HpssConfig config = {
       .real_spectrum_size = 257U,
-      .time_window_size = HPSS_TIME_WINDOW_MEDIUM,
-      .freq_window_size = HPSS_FREQ_WINDOW_MEDIUM,
   };
   HpssFilter* filter = hpss_filter_initialize(config);
   TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
 
-  // Check latency
+  // Check latency is 0 (sliding HPSS is causal)
   uint32_t latency = hpss_filter_get_latency_frames(filter);
-  TEST_ASSERT(latency == 8U, "Latency should be 8 frames for 17-frame window");
+  TEST_ASSERT(latency == 0U, "Latency should be 0 frames for sliding HPSS");
 
   float current_mag[257];
   float delayed_mag[257];
@@ -76,8 +72,8 @@ void test_hpss_filter(void) {
 
   // 4. Process multiple frames with constant spectrum
   for (uint32_t frame = 0; frame < 20; ++frame) {
-    bool ok =
-        hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
+    bool ok = hpss_filter_process(filter, current_mag, NULL, delayed_mag,
+                                  mask_h, mask_p);
     TEST_ASSERT(ok, "hpss_filter_process should succeed");
   }
 
@@ -91,7 +87,7 @@ void test_hpss_filter(void) {
 
   hpss_filter_free(filter);
 
-  // 5. Test transient onset detection
+  // 5. Test transient detection immediately on transient frame (0 latency)
   filter = hpss_filter_initialize(config);
   TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
 
@@ -100,144 +96,189 @@ void test_hpss_filter(void) {
     current_mag[i] = 0.01f;
   }
   for (uint32_t frame = 0; frame < 20; ++frame) {
-    (void)hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
+    (void)hpss_filter_process(filter, current_mag, NULL, delayed_mag, mask_h,
+                              mask_p);
   }
+  TEST_ASSERT(!hpss_filter_is_transient_detected(filter),
+              "Baseline quiet should be harmonic (no transient)");
 
   // Feed sharp transient frame (huge broadband jump)
   for (uint32_t i = 0; i < 257; ++i) {
     current_mag[i] = 5.0f;
   }
-  (void)hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
+  (void)hpss_filter_process(filter, current_mag, NULL, delayed_mag, mask_h,
+                            mask_p);
 
-  // Feed quiet frames until the transient reaches center frame (latency frames
-  // later)
+  // Transient detected immediately on the exact arrival frame!
+  TEST_ASSERT(hpss_filter_is_transient_detected(filter),
+              "Transient frame should report transient detected immediately");
+
+  // Feed quiet frames to ensure it returns to harmonic state
   for (uint32_t i = 0; i < 257; ++i) {
     current_mag[i] = 0.01f;
   }
-  for (uint32_t frame = 0; frame < latency; ++frame) {
-    (void)hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
+  for (uint32_t frame = 0; frame < 20; ++frame) {
+    (void)hpss_filter_process(filter, current_mag, NULL, delayed_mag, mask_h,
+                              mask_p);
   }
-
-  // When the transient is in the center frame, mask_p should dominate (high
-  // percussive weight)
-  float avg_p = 0.0f;
-  for (uint32_t k = 0; k < 257; ++k) {
-    avg_p += mask_p[k];
-  }
-  avg_p /= 257.0f;
-  TEST_ASSERT(avg_p > 0.5f,
-              "Percussive mask should dominate on transient frame");
+  TEST_ASSERT(!hpss_filter_is_transient_detected(filter),
+              "Quiet frames after transient should return to harmonic state");
 
   hpss_filter_free(filter);
 
-  // 6. Test Dynamic Quality Mode Reconfiguration
+  // 6. Test Quality Mode On/Off
   filter = hpss_filter_initialize(config);
   TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
-  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 8U,
-              "Default latency is 8");
-
-  // Switch to Low
-  hpss_filter_set_quality_mode(filter, HPSS_QUALITY_LOW);
-  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 4U,
-              "Low quality latency should be 4 frames");
-  for (uint32_t frame = 0; frame < 10; ++frame) {
-    bool ok =
-        hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
-    TEST_ASSERT(ok, "Process on Low quality mode should succeed");
-  }
-
-  // Switch to High
-  hpss_filter_set_quality_mode(filter, HPSS_QUALITY_HIGH);
-  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 16U,
-              "High quality latency should be 16 frames");
-  for (uint32_t frame = 0; frame < 10; ++frame) {
-    bool ok =
-        hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
-    TEST_ASSERT(ok, "Process on High quality mode should succeed");
-  }
+  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 0U,
+              "Sliding HPSS latency is 0");
 
   // Switch to Off
   hpss_filter_set_quality_mode(filter, HPSS_QUALITY_OFF);
-  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 0U,
-              "Off quality latency should be 0 frames");
   for (uint32_t frame = 0; frame < 10; ++frame) {
-    bool ok =
-        hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
+    bool ok = hpss_filter_process(filter, current_mag, NULL, delayed_mag,
+                                  mask_h, mask_p);
     TEST_ASSERT(ok, "Process on Off quality mode should succeed");
     TEST_ASSERT(delayed_mag[10] == current_mag[10],
                 "Delayed magnitude should match current magnitude in Off mode");
     TEST_ASSERT(mask_h[10] == 1.0f, "Harmonic mask should be 1.0 in Off mode");
   }
 
-  // Switch back to Medium
+  // Switch back to Medium (active)
   hpss_filter_set_quality_mode(filter, HPSS_QUALITY_MEDIUM);
-  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 8U,
-              "Medium quality latency should be 8 frames");
-  // Test redundant mode set
-  hpss_filter_set_quality_mode(filter, HPSS_QUALITY_MEDIUM);
-  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 8U,
-              "Medium quality latency should remain 8 frames");
-
   for (uint32_t frame = 0; frame < 10; ++frame) {
-    bool ok =
-        hpss_filter_process(filter, current_mag, delayed_mag, mask_h, mask_p);
+    bool ok = hpss_filter_process(filter, current_mag, NULL, delayed_mag,
+                                  mask_h, mask_p);
     TEST_ASSERT(ok, "Process on Medium quality mode should succeed");
   }
 
-  // Switch to invalid/default mode
-  hpss_filter_set_quality_mode(filter, (HpssQualityMode)999);
-  TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 8U,
-              "Default quality latency should be 8 frames");
-
   hpss_filter_free(filter);
 
-  // 7. Test even window configuration
-  HpssConfig even_cfg = {
-      .real_spectrum_size = 257U,
-      .time_window_size = 16U,
-      .freq_window_size = 16U,
-  };
-  HpssFilter* even_filter = hpss_filter_initialize(even_cfg);
-  TEST_ASSERT(even_filter != NULL, "Even config should be normalized to odd");
-  TEST_ASSERT(hpss_filter_get_latency_frames(even_filter) == 8U,
-              "16 window size rounds to 17, latency 8");
-  hpss_filter_free(even_filter);
+  // 7. Test Sensitivity Adjustment
+  filter = hpss_filter_initialize(config);
+  TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
+  hpss_filter_set_sensitivity(filter, 0.0f);
+  hpss_filter_set_sensitivity(filter, 1.0f);
+  hpss_filter_set_sensitivity(filter, 0.5f);
+  hpss_filter_free(filter);
 
-  // 8. Test oversized window configuration (clamping to HPSS_TIME_WINDOW_MAX)
-  HpssConfig oversized_cfg = {
-      .real_spectrum_size = 257U,
-      .time_window_size = 101U,
-      .freq_window_size = 17U,
-  };
-  HpssFilter* oversized_filter = hpss_filter_initialize(oversized_cfg);
-  TEST_ASSERT(oversized_filter != NULL, "Oversized config should initialize");
-  TEST_ASSERT(hpss_filter_get_latency_frames(oversized_filter) ==
-                  (HPSS_TIME_WINDOW_MAX - 1U) / 2U,
-              "Oversized window clamped to MAX");
-  for (int i = 0; i < (int)HPSS_TIME_WINDOW_MAX + 5; ++i) {
-    bool ok = hpss_filter_process(oversized_filter, current_mag, delayed_mag,
-                                  mask_h, mask_p);
-    TEST_ASSERT(ok, "Oversized filter processing should succeed");
-  }
-  hpss_filter_free(oversized_filter);
-
-  // 9. Test NULL safety
+  // 8. Test NULL safety
   hpss_filter_set_quality_mode(NULL, HPSS_QUALITY_LOW);
+  hpss_filter_set_sensitivity(NULL, 0.5f);
   TEST_ASSERT(hpss_filter_get_latency_frames(NULL) == 0U, "NULL latency is 0");
   TEST_ASSERT(hpss_filter_get_onset_ratio(NULL) == 0.0f, "NULL onset ratio 0");
-  TEST_ASSERT(hpss_filter_process(NULL, current_mag, delayed_mag, mask_h,
+  TEST_ASSERT(hpss_filter_is_transient_detected(NULL) == false,
+              "NULL transient detected is false");
+  TEST_ASSERT(hpss_filter_process(NULL, current_mag, NULL, delayed_mag, mask_h,
                                   mask_p) == false,
               "NULL filter process fails");
   filter = hpss_filter_initialize(config);
-  TEST_ASSERT(
-      hpss_filter_process(filter, NULL, delayed_mag, mask_h, mask_p) == false,
-      "NULL magnitude process fails");
+  TEST_ASSERT(hpss_filter_is_transient_detected(filter) == false,
+              "Initial transient detected is false");
+  TEST_ASSERT(hpss_filter_process(filter, NULL, NULL, delayed_mag, mask_h,
+                                  mask_p) == false,
+              "NULL magnitude process fails");
   hpss_filter_free(filter);
 
   printf("✓ HPSS Filter tests passed\n");
 }
 
+void test_hpss_noise_only(void) {
+  printf("Testing HPSS noise-only classification...\n");
+
+  HpssConfig config = {
+      .real_spectrum_size = 257U,
+  };
+  HpssFilter* filter = hpss_filter_initialize(config);
+  TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
+
+  float current_mag[257];
+  float noise_floor[257];
+  float delayed_mag[257];
+  float mask_h[257];
+  float mask_p[257];
+
+  for (uint32_t i = 0; i < 257; ++i) {
+    noise_floor[i] = 0.15f;
+  }
+
+  uint32_t rng_state = 12345U;
+  uint32_t false_transient_count = 0;
+  for (uint32_t frame = 0; frame < 60; ++frame) {
+    for (uint32_t i = 0; i < 257; ++i) {
+      rng_state = rng_state * 1103515245U + 12345U;
+      float r = 0.05f + 0.20f * ((float)(rng_state >> 16) / 65535.0f);
+      current_mag[i] = r;
+    }
+    (void)hpss_filter_process(filter, current_mag, noise_floor, delayed_mag,
+                              mask_h, mask_p);
+
+    if (frame >= 5U) {
+      if (hpss_filter_is_transient_detected(filter)) {
+        false_transient_count++;
+      }
+    }
+  }
+
+  TEST_ASSERT(false_transient_count == 0,
+              "Stationary noise should never trigger transient detection");
+
+  hpss_filter_free(filter);
+
+  printf("✓ HPSS noise-only classification tests passed\n");
+}
+
+void test_hpss_subband_transient_in_noise(void) {
+  printf("Testing HPSS subband transient detection in stationary noise...\n");
+
+  HpssConfig config = {
+      .real_spectrum_size = 257U,
+  };
+  HpssFilter* filter = hpss_filter_initialize(config);
+  TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
+  hpss_filter_set_sensitivity(filter, 0.8f); // 80% sensitivity
+
+  float current_mag[257];
+  float noise_floor[257];
+  float delayed_mag[257];
+  float mask_h[257];
+  float mask_p[257];
+
+  for (uint32_t i = 0; i < 257; ++i) {
+    noise_floor[i] = (i < 40) ? 2.0f : 0.2f;
+  }
+
+  // 1. Feed baseline heavy stationary noise (e.g. low-frequency hum/rumble + noise)
+  for (uint32_t frame = 0; frame < 30; ++frame) {
+    for (uint32_t i = 0; i < 257; ++i) {
+      current_mag[i] = (i < 40) ? 2.0f : 0.2f; // Heavy bass noise
+    }
+    (void)hpss_filter_process(filter, current_mag, noise_floor, delayed_mag,
+                              mask_h, mask_p);
+  }
+  TEST_ASSERT(!hpss_filter_is_transient_detected(filter),
+              "Baseline noise with heavy rumble should be harmonic");
+
+  // 2. Inject high-frequency localized transient (e.g. snare/hat/pluck attack in bins 80-160)
+  for (uint32_t i = 0; i < 257; ++i) {
+    current_mag[i] = (i < 40) ? 2.0f : 0.2f;
+    if (i >= 80 && i <= 160) {
+      current_mag[i] += 1.5f; // Localized attack
+    }
+  }
+  (void)hpss_filter_process(filter, current_mag, noise_floor, delayed_mag,
+                            mask_h, mask_p);
+
+  // Transient should be detected immediately on the attack frame!
+  TEST_ASSERT(hpss_filter_is_transient_detected(filter),
+              "Subband transient should be detected amidst heavy noise");
+
+  hpss_filter_free(filter);
+  printf("✓ HPSS subband transient in noise tests passed\n");
+}
+
 int main(void) {
   test_hpss_filter();
+  test_hpss_noise_only();
+  test_hpss_subband_transient_in_noise();
   return 0;
 }

--- a/tests/test_hpss_filter.c
+++ b/tests/test_hpss_filter.c
@@ -126,44 +126,38 @@ void test_hpss_filter(void) {
 
   hpss_filter_free(filter);
 
-  // 6. Test Quality Mode On/Off
+  // 6. Test Enable / Disable On/Off
   filter = hpss_filter_initialize(config);
   TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
   TEST_ASSERT(hpss_filter_get_latency_frames(filter) == 0U,
               "Sliding HPSS latency is 0");
 
-  // Switch to Off
-  hpss_filter_set_quality_mode(filter, HPSS_QUALITY_OFF);
+  // Disable HPSS
+  hpss_filter_set_enabled(filter, false);
   for (uint32_t frame = 0; frame < 10; ++frame) {
     bool ok = hpss_filter_process(filter, current_mag, NULL, delayed_mag,
                                   mask_h, mask_p);
-    TEST_ASSERT(ok, "Process on Off quality mode should succeed");
+    TEST_ASSERT(ok, "Process on disabled filter should succeed");
     TEST_ASSERT(delayed_mag[10] == current_mag[10],
-                "Delayed magnitude should match current magnitude in Off mode");
-    TEST_ASSERT(mask_h[10] == 1.0f, "Harmonic mask should be 1.0 in Off mode");
+                "Delayed magnitude should match current magnitude when disabled");
+    TEST_ASSERT(mask_h[10] == 1.0f, "Harmonic mask should be 1.0 when disabled");
+    TEST_ASSERT(mask_p[10] == 0.0f, "Percussive mask should be 0.0 when disabled");
   }
+  TEST_ASSERT(!hpss_filter_is_transient_detected(filter),
+              "Disabled HPSS should not report transients");
 
-  // Switch back to Medium (active)
-  hpss_filter_set_quality_mode(filter, HPSS_QUALITY_MEDIUM);
+  // Enable HPSS back
+  hpss_filter_set_enabled(filter, true);
   for (uint32_t frame = 0; frame < 10; ++frame) {
     bool ok = hpss_filter_process(filter, current_mag, NULL, delayed_mag,
                                   mask_h, mask_p);
-    TEST_ASSERT(ok, "Process on Medium quality mode should succeed");
+    TEST_ASSERT(ok, "Process on enabled filter should succeed");
   }
 
   hpss_filter_free(filter);
 
-  // 7. Test Sensitivity Adjustment
-  filter = hpss_filter_initialize(config);
-  TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
-  hpss_filter_set_sensitivity(filter, 0.0f);
-  hpss_filter_set_sensitivity(filter, 1.0f);
-  hpss_filter_set_sensitivity(filter, 0.5f);
-  hpss_filter_free(filter);
-
-  // 8. Test NULL safety
-  hpss_filter_set_quality_mode(NULL, HPSS_QUALITY_LOW);
-  hpss_filter_set_sensitivity(NULL, 0.5f);
+  // 7. Test NULL safety
+  hpss_filter_set_enabled(NULL, false);
   TEST_ASSERT(hpss_filter_get_latency_frames(NULL) == 0U, "NULL latency is 0");
   TEST_ASSERT(hpss_filter_get_onset_ratio(NULL) == 0.0f, "NULL onset ratio 0");
   TEST_ASSERT(hpss_filter_is_transient_detected(NULL) == false,
@@ -235,7 +229,6 @@ void test_hpss_subband_transient_in_noise(void) {
   };
   HpssFilter* filter = hpss_filter_initialize(config);
   TEST_ASSERT(filter != NULL, "HPSS filter initialization should succeed");
-  hpss_filter_set_sensitivity(filter, 0.8f); // 80% sensitivity
 
   float current_mag[257];
   float noise_floor[257];

--- a/tests/test_specbleach_2d_denoiser.c
+++ b/tests/test_specbleach_2d_denoiser.c
@@ -350,19 +350,13 @@ void test_process_loop(void) {
   specbleach_2d_load_parameters(h, params);
   specbleach_2d_process(h, 1024, in_buf, out_buf);
   uint32_t lat1 = specbleach_2d_get_latency(h);
-  TEST_ASSERT(lat1 >= lat0, "Low quality 2D latency >= Off");
-
-  params.hpss_quality_mode = HPSS_QUALITY_MEDIUM;
-  specbleach_2d_load_parameters(h, params);
-  specbleach_2d_process(h, 1024, in_buf, out_buf);
-  uint32_t lat2 = specbleach_2d_get_latency(h);
-  TEST_ASSERT(lat2 > lat1, "Medium quality 2D latency > Low");
+  TEST_ASSERT(lat1 == lat0, "Sliding HPSS introduces zero lookahead latency");
 
   params.hpss_quality_mode = HPSS_QUALITY_HIGH;
   specbleach_2d_load_parameters(h, params);
   specbleach_2d_process(h, 1024, in_buf, out_buf);
   uint32_t lat3 = specbleach_2d_get_latency(h);
-  TEST_ASSERT(lat3 > lat2, "High quality 2D latency > Medium");
+  TEST_ASSERT(lat3 == lat0, "Sliding HPSS introduces zero lookahead latency");
 
   // NULL checks
   TEST_ASSERT(specbleach_2d_get_tonal_mask(NULL) == NULL, "NULL 2D tonal mask");

--- a/tests/test_specbleach_2d_denoiser.c
+++ b/tests/test_specbleach_2d_denoiser.c
@@ -298,7 +298,7 @@ void test_process_loop(void) {
   params.learn_noise = 0;
   params.tonal_reduction = 0.5f;
   params.reduction_amount = 20.0f;
-  params.hpss_quality_mode = HPSS_QUALITY_MEDIUM;
+  params.hpss_enable = 1;
   specbleach_2d_load_parameters(h, params);
   specbleach_2d_process(h, 1024, in_buf, out_buf);
   for (int i = 0; i < 1024; ++i) {
@@ -341,22 +341,16 @@ void test_process_loop(void) {
   params.reduction_curve_enabled = false;
   params.reduction_curve_bias = NULL;
 
-  params.hpss_quality_mode = HPSS_QUALITY_OFF;
+  params.hpss_enable = 0;
   specbleach_2d_load_parameters(h, params);
   specbleach_2d_process(h, 1024, in_buf, out_buf);
   uint32_t lat0 = specbleach_2d_get_latency(h);
 
-  params.hpss_quality_mode = HPSS_QUALITY_LOW;
+  params.hpss_enable = 1;
   specbleach_2d_load_parameters(h, params);
   specbleach_2d_process(h, 1024, in_buf, out_buf);
   uint32_t lat1 = specbleach_2d_get_latency(h);
   TEST_ASSERT(lat1 == lat0, "Sliding HPSS introduces zero lookahead latency");
-
-  params.hpss_quality_mode = HPSS_QUALITY_HIGH;
-  specbleach_2d_load_parameters(h, params);
-  specbleach_2d_process(h, 1024, in_buf, out_buf);
-  uint32_t lat3 = specbleach_2d_get_latency(h);
-  TEST_ASSERT(lat3 == lat0, "Sliding HPSS introduces zero lookahead latency");
 
   // NULL checks
   TEST_ASSERT(specbleach_2d_get_tonal_mask(NULL) == NULL, "NULL 2D tonal mask");

--- a/tests/test_specbleach_denoiser.c
+++ b/tests/test_specbleach_denoiser.c
@@ -424,7 +424,7 @@ int main(void) {
       .learn_noise = false,
       .tonal_reduction = 0.5f,
       .reduction_amount = 20.0f,
-      .hpss_quality_mode = 2,
+      .hpss_enable = 1,
   };
   specbleach_load_parameters(h, t_params);
   specbleach_process(h, 1024, in_buf, out_buf);
@@ -459,22 +459,16 @@ int main(void) {
   t_params.reduction_curve_enabled = false;
   t_params.reduction_curve_bias = NULL;
 
-  t_params.hpss_quality_mode = HPSS_QUALITY_OFF;
+  t_params.hpss_enable = 0;
   specbleach_load_parameters(h, t_params);
   specbleach_process(h, 1024, in_buf, out_buf);
   uint32_t lat0 = specbleach_get_latency(h);
 
-  t_params.hpss_quality_mode = HPSS_QUALITY_LOW;
+  t_params.hpss_enable = 1;
   specbleach_load_parameters(h, t_params);
   specbleach_process(h, 1024, in_buf, out_buf);
   uint32_t lat1 = specbleach_get_latency(h);
   TEST_ASSERT(lat1 == lat0, "Sliding HPSS introduces zero lookahead latency");
-
-  t_params.hpss_quality_mode = HPSS_QUALITY_HIGH;
-  specbleach_load_parameters(h, t_params);
-  specbleach_process(h, 1024, in_buf, out_buf);
-  uint32_t lat3 = specbleach_get_latency(h);
-  TEST_ASSERT(lat3 == lat0, "Sliding HPSS introduces zero lookahead latency");
 
   // Verify NULL handle protections
   TEST_ASSERT(specbleach_get_latency(NULL) == 0, "NULL latency");

--- a/tests/test_specbleach_denoiser.c
+++ b/tests/test_specbleach_denoiser.c
@@ -468,19 +468,13 @@ int main(void) {
   specbleach_load_parameters(h, t_params);
   specbleach_process(h, 1024, in_buf, out_buf);
   uint32_t lat1 = specbleach_get_latency(h);
-  TEST_ASSERT(lat1 > lat0, "Low quality latency > Off");
-
-  t_params.hpss_quality_mode = HPSS_QUALITY_MEDIUM;
-  specbleach_load_parameters(h, t_params);
-  specbleach_process(h, 1024, in_buf, out_buf);
-  uint32_t lat2 = specbleach_get_latency(h);
-  TEST_ASSERT(lat2 > lat1, "Medium quality latency > Low");
+  TEST_ASSERT(lat1 == lat0, "Sliding HPSS introduces zero lookahead latency");
 
   t_params.hpss_quality_mode = HPSS_QUALITY_HIGH;
   specbleach_load_parameters(h, t_params);
   specbleach_process(h, 1024, in_buf, out_buf);
   uint32_t lat3 = specbleach_get_latency(h);
-  TEST_ASSERT(lat3 > lat2, "High quality latency > Medium");
+  TEST_ASSERT(lat3 == lat0, "Sliding HPSS introduces zero lookahead latency");
 
   // Verify NULL handle protections
   TEST_ASSERT(specbleach_get_latency(NULL) == 0, "NULL latency");

--- a/tests/test_specbleach_processor_core.c
+++ b/tests/test_specbleach_processor_core.c
@@ -176,6 +176,8 @@ void test_params_sanitize_functions(void) {
       .suppression_strength = 80.0f,
       .aggressiveness = 1.0f,
       .tonal_reduction = -6.0f,
+      .hpss_quality_mode = 1,
+      .hpss_sensitivity = 0.7f,
       .noise_profile_offset_db = 2.0f,
       .reduction_curve_bias = NULL,
       .reduction_curve_enabled = false,
@@ -185,6 +187,7 @@ void test_params_sanitize_functions(void) {
   TEST_ASSERT(sp1.learn_noise == true, "Sanitize learn_noise");
   TEST_FLOAT_CLOSE(sp1.whitening_factor, 1.0f, 1e-4f);
   TEST_FLOAT_CLOSE(sp1.suppression_strength, 0.8f, 1e-4f);
+  TEST_FLOAT_CLOSE(sp1.hpss_sensitivity, 0.7f, 1e-4f);
   TEST_FLOAT_CLOSE(sp1.noise_profile_offset_linear, 1.2589f, 1e-3f);
   TEST_ASSERT(sp1.reduction_curve_bias == NULL, "Sanitize disabled curve bias");
 
@@ -200,6 +203,8 @@ void test_params_sanitize_functions(void) {
       .suppression_strength = 100.0f,
       .aggressiveness = 2.0f,
       .tonal_reduction = -3.0f,
+      .hpss_quality_mode = 2,
+      .hpss_sensitivity = 0.85f,
       .noise_profile_offset_db = -6.0f,
       .reduction_curve_bias = (const float*)0x1234,
       .reduction_curve_enabled = true,
@@ -209,6 +214,7 @@ void test_params_sanitize_functions(void) {
   TEST_ASSERT(sp2.residual_listen == true, "Sanitize 2d residual_listen");
   TEST_FLOAT_CLOSE(sp2.whitening_factor, 0.5f, 1e-4f);
   TEST_FLOAT_CLOSE(sp2.suppression_strength, 1.0f, 1e-4f);
+  TEST_FLOAT_CLOSE(sp2.hpss_sensitivity, 0.85f, 1e-4f);
   TEST_FLOAT_CLOSE(sp2.noise_profile_offset_linear, 0.5011f, 1e-3f);
   TEST_ASSERT(sp2.reduction_curve_bias == (const float*)0x1234,
               "Sanitize enabled curve bias ptr");

--- a/tests/test_specbleach_processor_core.c
+++ b/tests/test_specbleach_processor_core.c
@@ -176,8 +176,7 @@ void test_params_sanitize_functions(void) {
       .suppression_strength = 80.0f,
       .aggressiveness = 1.0f,
       .tonal_reduction = -6.0f,
-      .hpss_quality_mode = 1,
-      .hpss_sensitivity = 0.7f,
+      .hpss_enable = 1,
       .noise_profile_offset_db = 2.0f,
       .reduction_curve_bias = NULL,
       .reduction_curve_enabled = false,
@@ -187,7 +186,7 @@ void test_params_sanitize_functions(void) {
   TEST_ASSERT(sp1.learn_noise == true, "Sanitize learn_noise");
   TEST_FLOAT_CLOSE(sp1.whitening_factor, 1.0f, 1e-4f);
   TEST_FLOAT_CLOSE(sp1.suppression_strength, 0.8f, 1e-4f);
-  TEST_FLOAT_CLOSE(sp1.hpss_sensitivity, 0.7f, 1e-4f);
+  TEST_ASSERT(sp1.hpss_enable == 1, "Sanitize hpss_enable");
   TEST_FLOAT_CLOSE(sp1.noise_profile_offset_linear, 1.2589f, 1e-3f);
   TEST_ASSERT(sp1.reduction_curve_bias == NULL, "Sanitize disabled curve bias");
 
@@ -203,8 +202,7 @@ void test_params_sanitize_functions(void) {
       .suppression_strength = 100.0f,
       .aggressiveness = 2.0f,
       .tonal_reduction = -3.0f,
-      .hpss_quality_mode = 2,
-      .hpss_sensitivity = 0.85f,
+      .hpss_enable = 1,
       .noise_profile_offset_db = -6.0f,
       .reduction_curve_bias = (const float*)0x1234,
       .reduction_curve_enabled = true,
@@ -214,7 +212,7 @@ void test_params_sanitize_functions(void) {
   TEST_ASSERT(sp2.residual_listen == true, "Sanitize 2d residual_listen");
   TEST_FLOAT_CLOSE(sp2.whitening_factor, 0.5f, 1e-4f);
   TEST_FLOAT_CLOSE(sp2.suppression_strength, 1.0f, 1e-4f);
-  TEST_FLOAT_CLOSE(sp2.hpss_sensitivity, 0.85f, 1e-4f);
+  TEST_ASSERT(sp2.hpss_enable == 1, "Sanitize 2d hpss_enable");
   TEST_FLOAT_CLOSE(sp2.noise_profile_offset_linear, 0.5011f, 1e-3f);
   TEST_ASSERT(sp2.reduction_curve_bias == (const float*)0x1234,
               "Sanitize enabled curve bias ptr");


### PR DESCRIPTION
Fixes #131

### Summary of Changes
- Replaced lookahead median filtering with causal sliding HPSS (Ono/Tachibana) for 0 lookahead latency.
- Added noise-floor adaptive gating and soft-knee power compression to percussive masks to eliminate edge tearing and pre-echo artifacts.
- Implemented stream recombination: `G_final = clamp((W_H * G_H) + W_P, 0.0, 1.0)` across 1D and 2D denoisers.
- Aligned internal circular buffer latencies across 1D and 2D pipelines to prevent phase tearing and transient softening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adjustable HPSS sensitivity controls for 1D and 2D denoising.
  * Added APIs to report when a transient was detected and protected.
  * HPSS now operates causally with zero lookahead latency.
  * Improved transient separation, including detection in noisy audio.

* **Bug Fixes**
  * Improved handling of noise floors and percussive content.
  * Updated default parameter handling for HPSS sensitivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->