### PR TITLE
feat(dsp): add tonal noise profile scale

### DIFF
--- a/include/specbleach_2d_denoiser.h
+++ b/include/specbleach_2d_denoiser.h
@@ -99,6 +99,12 @@ typedef struct SpectralBleach2DDenoiserParameters {
    * the 1.0f default. Values > 1.0 shift threshold higher (more reduction). */
   float noise_profile_scale;
 
+  /* Tonal Noise Profile Linear Scale — multiplier applied to the noise power
+   * spectrum only at detected tonal components. Positive inputs are clamped to
+   * [0.01f, 100.0f]. Non-positive inputs use the 1.0f default. Values > 1.0
+   * shift threshold higher (more reduction) at tonal bins. */
+  float tonal_noise_profile_scale;
+
   /* Frequency-dependent reduction bias curve.
    * Array of dB offsets per frequency bin, or NULL if disabled.
    * Positive values = more reduction at that frequency.

--- a/include/specbleach_2d_denoiser.h
+++ b/include/specbleach_2d_denoiser.h
@@ -99,12 +99,6 @@ typedef struct SpectralBleach2DDenoiserParameters {
    * the 1.0f default. Values > 1.0 shift threshold higher (more reduction). */
   float noise_profile_scale;
 
-  /* Tonal Noise Profile Linear Scale — multiplier applied to the noise power
-   * spectrum only at detected tonal components. Positive inputs are clamped to
-   * [0.01f, 100.0f]. Non-positive inputs use the 1.0f default. Values > 1.0
-   * shift threshold higher (more reduction) at tonal bins. */
-  float tonal_noise_profile_scale;
-
   /* Frequency-dependent reduction bias curve.
    * Array of dB offsets per frequency bin, or NULL if disabled.
    * Positive values = more reduction at that frequency.
@@ -114,6 +108,12 @@ typedef struct SpectralBleach2DDenoiserParameters {
   /* Enables the reduction curve bias. When false, reduction_curve_bias
    * is ignored even if non-NULL. */
   bool reduction_curve_enabled;
+
+  /* Tonal Noise Profile Linear Scale — multiplier applied to the noise power
+   * spectrum only at detected tonal components. Positive inputs are clamped to
+   * [0.01f, 100.0f]. Non-positive inputs use the 1.0f default. Values > 1.0
+   * shift threshold higher (more reduction) at tonal bins. */
+  float tonal_noise_profile_scale;
 } SpectralBleach2DDenoiserParameters;
 
 /**

--- a/include/specbleach_denoiser.h
+++ b/include/specbleach_denoiser.h
@@ -80,6 +80,12 @@ typedef struct SpectralBleachDenoiserParameters {
    * the 1.0f default. Values > 1.0 shift threshold higher (more reduction). */
   float noise_profile_scale;
 
+  /* Tonal Noise Profile Linear Scale — multiplier applied to the noise power
+   * spectrum only at detected tonal components. Positive inputs are clamped to
+   * [0.01f, 100.0f]. Non-positive inputs use the 1.0f default. Values > 1.0
+   * shift threshold higher (more reduction) at tonal bins. */
+  float tonal_noise_profile_scale;
+
   /* Frequency-dependent reduction bias curve.
    * Array of dB offsets per frequency bin, or NULL if disabled.
    * Positive values = more reduction at that frequency.

--- a/include/specbleach_denoiser.h
+++ b/include/specbleach_denoiser.h
@@ -80,12 +80,6 @@ typedef struct SpectralBleachDenoiserParameters {
    * the 1.0f default. Values > 1.0 shift threshold higher (more reduction). */
   float noise_profile_scale;
 
-  /* Tonal Noise Profile Linear Scale — multiplier applied to the noise power
-   * spectrum only at detected tonal components. Positive inputs are clamped to
-   * [0.01f, 100.0f]. Non-positive inputs use the 1.0f default. Values > 1.0
-   * shift threshold higher (more reduction) at tonal bins. */
-  float tonal_noise_profile_scale;
-
   /* Frequency-dependent reduction bias curve.
    * Array of dB offsets per frequency bin, or NULL if disabled.
    * Positive values = more reduction at that frequency.
@@ -95,6 +89,12 @@ typedef struct SpectralBleachDenoiserParameters {
   /* Enables the reduction curve bias. When false, reduction_curve_bias
    * is ignored even if non-NULL. */
   bool reduction_curve_enabled;
+
+  /* Tonal Noise Profile Linear Scale — multiplier applied to the noise power
+   * spectrum only at detected tonal components. Positive inputs are clamped to
+   * [0.01f, 100.0f]. Non-positive inputs use the 1.0f default. Values > 1.0
+   * shift threshold higher (more reduction) at tonal bins. */
+  float tonal_noise_profile_scale;
 } SpectralBleachDenoiserParameters;
 
 /**

--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -343,6 +343,11 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
       .noise_estimator = self->noise_estimator,
       .noise_profile_offset_linear =
           self->denoise_parameters.noise_profile_offset_linear,
+      .tonal_noise_profile_offset_linear =
+          self->denoise_parameters.tonal_noise_profile_offset_linear,
+      // Previous frame's tonal mask (one-frame latency) is used to apply the
+      // tonal threshold offset at detected tonal bins
+      .tonal_mask = tonal_reducer_get_mask(self->tonal_reducer),
   };
   denoiser_profile_core_update(profile_params, reference_spectrum);
 

--- a/src/processors/denoiser/spectral_denoiser.h
+++ b/src/processors/denoiser/spectral_denoiser.h
@@ -40,6 +40,7 @@ typedef struct DenoiserParameters {
   float tonal_reduction; /**< 0.0 to 1.0 (Phase 3) */
   int hpss_enable;       /**< 0=disabled, 1=enabled */
   float noise_profile_offset_linear; /**< Linear scalar for noise profile */
+  float tonal_noise_profile_offset_linear; /**< Linear scalar at tonal bins */
   const float* reduction_curve_bias; /**< Per-bin dB bias, NULL = disabled */
   bool reduction_curve_enabled;
 } DenoiserParameters;

--- a/src/processors/denoiser2d/spectral_2d_denoiser.c
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.c
@@ -402,6 +402,11 @@ bool spectral_2d_denoiser_run(SpectralProcessorHandle instance,
       .noise_estimator = self->noise_estimator,
       .noise_profile_offset_linear =
           self->parameters.noise_profile_offset_linear,
+      .tonal_noise_profile_offset_linear =
+          self->parameters.tonal_noise_profile_offset_linear,
+      // Previous frame's tonal mask (one-frame latency) is used to apply the
+      // tonal threshold offset at detected tonal bins
+      .tonal_mask = tonal_reducer_get_mask(self->tonal_reducer),
   };
   denoiser_profile_core_update(profile_params, reference_spectrum);
 

--- a/src/processors/denoiser2d/spectral_2d_denoiser.h
+++ b/src/processors/denoiser2d/spectral_2d_denoiser.h
@@ -44,6 +44,7 @@ typedef struct Denoiser2DParameters {
   float tonal_reduction; /**< 0.0 to 1.0 (Phase 3) */
   int hpss_enable;       /**< 0=disabled, 1=enabled */
   float noise_profile_offset_linear; /**< Linear scalar for noise profile */
+  float tonal_noise_profile_offset_linear; /**< Linear scalar at tonal bins */
   const float* reduction_curve_bias; /**< Per-bin dB bias, NULL = disabled */
   bool reduction_curve_enabled;
 } Denoiser2DParameters;

--- a/src/processors/specbleach_processor_core.c
+++ b/src/processors/specbleach_processor_core.c
@@ -45,6 +45,10 @@ DenoiserParameters sb_denoiser_params_sanitize(
           fmaxf(0.01f, fminf(100.0f, parameters.noise_profile_scale > 0.0f
                                          ? parameters.noise_profile_scale
                                          : 1.0f)),
+      .tonal_noise_profile_offset_linear =
+          fmaxf(0.01f, fminf(100.0f, parameters.tonal_noise_profile_scale > 0.0f
+                                         ? parameters.tonal_noise_profile_scale
+                                         : 1.0f)),
       .reduction_curve_bias = parameters.reduction_curve_enabled
                                   ? parameters.reduction_curve_bias
                                   : NULL,
@@ -73,6 +77,10 @@ Denoiser2DParameters sb_denoiser_2d_params_sanitize(
       .noise_profile_offset_linear =
           fmaxf(0.01f, fminf(100.0f, parameters.noise_profile_scale > 0.0f
                                          ? parameters.noise_profile_scale
+                                         : 1.0f)),
+      .tonal_noise_profile_offset_linear =
+          fmaxf(0.01f, fminf(100.0f, parameters.tonal_noise_profile_scale > 0.0f
+                                         ? parameters.tonal_noise_profile_scale
                                          : 1.0f)),
       .reduction_curve_bias = parameters.reduction_curve_enabled
                                   ? parameters.reduction_curve_bias

--- a/src/shared/denoiser_logic/core/denoiser_profile_core.c
+++ b/src/shared/denoiser_logic/core/denoiser_profile_core.c
@@ -130,6 +130,7 @@ void denoiser_profile_core_update(DenoiserProfileCoreParams params,
   const bool tonal_active = params.tonal_noise_profile_offset_linear != 1.0f &&
                             params.tonal_mask != NULL;
   if (broadband_offset != 1.0f || tonal_active) {
+    sb_simd_state_t old_simd_state = sb_simd_enable_ftz_daz();
     const float tonal_offset = params.tonal_noise_profile_offset_linear;
     for (uint32_t k = 0U; k < params.spectrum_size; k++) {
       float scale = broadband_offset;
@@ -140,5 +141,6 @@ void denoiser_profile_core_update(DenoiserProfileCoreParams params,
       }
       params.noise_spectrum[k] *= scale;
     }
+    sb_simd_restore_state(old_simd_state);
   }
 }

--- a/src/shared/denoiser_logic/core/denoiser_profile_core.c
+++ b/src/shared/denoiser_logic/core/denoiser_profile_core.c
@@ -122,10 +122,23 @@ void denoiser_profile_core_update(DenoiserProfileCoreParams params,
                         params.spectrum_size, params.param_aggressiveness);
   }
 
-  // Apply noise profile offset (threshold scalar shift)
-  if (params.noise_profile_offset_linear != 1.0f) {
+  // Apply noise profile offset (threshold scalar shift). When a distinct
+  // tonal offset is provided together with the previous frame's tonal mask,
+  // both offsets are blended per-bin using the tonal mask strength so tonal
+  // components receive their own threshold shift.
+  const float broadband_offset = params.noise_profile_offset_linear;
+  const bool tonal_active = params.tonal_noise_profile_offset_linear != 1.0f &&
+                            params.tonal_mask != NULL;
+  if (broadband_offset != 1.0f || tonal_active) {
+    const float tonal_offset = params.tonal_noise_profile_offset_linear;
     for (uint32_t k = 0U; k < params.spectrum_size; k++) {
-      params.noise_spectrum[k] *= params.noise_profile_offset_linear;
+      float scale = broadband_offset;
+      if (tonal_active && params.tonal_mask[k] > 0.0f) {
+        float mask = fminf(params.tonal_mask[k], 1.0f);
+        mask = sqrtf(sqrtf(mask));
+        scale = (broadband_offset * (1.0f - mask)) + (tonal_offset * mask);
+      }
+      params.noise_spectrum[k] *= scale;
     }
   }
 }

--- a/src/shared/denoiser_logic/core/denoiser_profile_core.h
+++ b/src/shared/denoiser_logic/core/denoiser_profile_core.h
@@ -42,6 +42,8 @@ typedef struct DenoiserProfileCoreParams {
   float* noise_spectrum; // Output buffer
   NoiseEstimator* noise_estimator;
   float noise_profile_offset_linear; // Linear scalar shift for noise threshold
+  float tonal_noise_profile_offset_linear; // Linear scalar shift at tonal bins
+  const float* tonal_mask; // Previous frame tonal mask (may be NULL)
 } DenoiserProfileCoreParams;
 
 /**

--- a/tests/test_specbleach_processor_core.c
+++ b/tests/test_specbleach_processor_core.c
@@ -178,6 +178,7 @@ void test_params_sanitize_functions(void) {
       .tonal_reduction_gain = 0.5f,
       .hpss_enable = 1,
       .noise_profile_scale = 1.5849f,
+      .tonal_noise_profile_scale = 3.9811f,
       .reduction_curve_bias = NULL,
       .reduction_curve_enabled = false,
   };
@@ -189,6 +190,7 @@ void test_params_sanitize_functions(void) {
   TEST_FLOAT_CLOSE(sp1.suppression_strength, 0.8f, 1e-4f);
   TEST_ASSERT(sp1.hpss_enable == 1, "Sanitize hpss_enable");
   TEST_FLOAT_CLOSE(sp1.noise_profile_offset_linear, 1.5849f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp1.tonal_noise_profile_offset_linear, 3.9811f, 1e-3f);
   TEST_ASSERT(sp1.reduction_curve_bias == NULL, "Sanitize disabled curve bias");
 
   SpectralBleach2DDenoiserParameters p2 = {
@@ -205,6 +207,7 @@ void test_params_sanitize_functions(void) {
       .tonal_reduction_gain = 0.7f,
       .hpss_enable = 1,
       .noise_profile_scale = 0.2512f,
+      .tonal_noise_profile_scale = 0.631f,
       .reduction_curve_bias = (const float*)0x1234,
       .reduction_curve_enabled = true,
   };
@@ -216,6 +219,7 @@ void test_params_sanitize_functions(void) {
   TEST_FLOAT_CLOSE(sp2.suppression_strength, 1.0f, 1e-4f);
   TEST_ASSERT(sp2.hpss_enable == 1, "Sanitize 2d hpss_enable");
   TEST_FLOAT_CLOSE(sp2.noise_profile_offset_linear, 0.2512f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp2.tonal_noise_profile_offset_linear, 0.631f, 1e-3f);
   TEST_ASSERT(sp2.reduction_curve_bias == (const float*)0x1234,
               "Sanitize enabled curve bias ptr");
 
@@ -223,41 +227,55 @@ void test_params_sanitize_functions(void) {
   SpectralBleachDenoiserParameters p_min = p1;
   p_min.reduction_gain = -5.0f;
   p_min.noise_profile_scale = -2.0f;
+  p_min.tonal_noise_profile_scale = -2.0f;
   DenoiserParameters sp_min = sb_denoiser_params_sanitize(p_min);
   TEST_FLOAT_CLOSE(sp_min.reduction_amount, 0.0f, 1e-3f);
   TEST_FLOAT_CLOSE(sp_min.noise_profile_offset_linear, 1.0f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp_min.tonal_noise_profile_offset_linear, 1.0f, 1e-3f);
 
   SpectralBleachDenoiserParameters p_scale_low = p1;
   p_scale_low.noise_profile_scale = 0.001f;
+  p_scale_low.tonal_noise_profile_scale = 0.001f;
   DenoiserParameters sp_scale_low = sb_denoiser_params_sanitize(p_scale_low);
   TEST_FLOAT_CLOSE(sp_scale_low.noise_profile_offset_linear, 0.01f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp_scale_low.tonal_noise_profile_offset_linear, 0.01f,
+                   1e-3f);
 
   SpectralBleachDenoiserParameters p_max = p1;
   p_max.reduction_gain = 5.0f;
   p_max.noise_profile_scale = 200.0f;
+  p_max.tonal_noise_profile_scale = 200.0f;
   DenoiserParameters sp_max = sb_denoiser_params_sanitize(p_max);
   TEST_FLOAT_CLOSE(sp_max.reduction_amount, 1.0f, 1e-3f);
   TEST_FLOAT_CLOSE(sp_max.noise_profile_offset_linear, 100.0f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp_max.tonal_noise_profile_offset_linear, 100.0f, 1e-3f);
 
   SpectralBleach2DDenoiserParameters p2_min = p2;
   p2_min.reduction_gain = -5.0f;
   p2_min.noise_profile_scale = -2.0f;
+  p2_min.tonal_noise_profile_scale = -2.0f;
   Denoiser2DParameters sp2_min = sb_denoiser_2d_params_sanitize(p2_min);
   TEST_FLOAT_CLOSE(sp2_min.reduction_amount, 0.0f, 1e-3f);
   TEST_FLOAT_CLOSE(sp2_min.noise_profile_offset_linear, 1.0f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp2_min.tonal_noise_profile_offset_linear, 1.0f, 1e-3f);
 
   SpectralBleach2DDenoiserParameters p2_scale_low = p2;
   p2_scale_low.noise_profile_scale = 0.001f;
+  p2_scale_low.tonal_noise_profile_scale = 0.001f;
   Denoiser2DParameters sp2_scale_low =
       sb_denoiser_2d_params_sanitize(p2_scale_low);
   TEST_FLOAT_CLOSE(sp2_scale_low.noise_profile_offset_linear, 0.01f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp2_scale_low.tonal_noise_profile_offset_linear, 0.01f,
+                   1e-3f);
 
   SpectralBleach2DDenoiserParameters p2_max = p2;
   p2_max.reduction_gain = 5.0f;
   p2_max.noise_profile_scale = 200.0f;
+  p2_max.tonal_noise_profile_scale = 200.0f;
   Denoiser2DParameters sp2_max = sb_denoiser_2d_params_sanitize(p2_max);
   TEST_FLOAT_CLOSE(sp2_max.reduction_amount, 1.0f, 1e-3f);
   TEST_FLOAT_CLOSE(sp2_max.noise_profile_offset_linear, 100.0f, 1e-3f);
+  TEST_FLOAT_CLOSE(sp2_max.tonal_noise_profile_offset_linear, 100.0f, 1e-3f);
 
   printf("✓ Params sanitize functions tests passed\n");
 }


### PR DESCRIPTION
## Summary
- Adds `tonal_noise_profile_scale` to the public 1D and 2D denoiser parameter structs (same clamping semantics as `noise_profile_scale`: [0.01, 100.0], default 1.0)
- `denoiser_profile_core_update` now blends broadband and tonal threshold scales per-bin using the previous frame's tonal mask (one-frame latency, real-time safe)
- When the tonal scale is 1.0 (linked mode) behavior is bit-identical to before

## Testing
- `test_specbleach_processor_core`: extended with clamp/round-trip assertions for the new field (1D + 2D)
- `test_noise_profile` and `test_audio_file_regression` pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate tonal noise-profile scaling for 1D and 2D denoisers.
  * Tonal scaling can be configured from 0.01× to 100×, with a default of 1×.
  * Improved noise reduction thresholding at detected tonal components.

* **Bug Fixes**
  * Tonal and broadband noise adjustments are now applied independently for more precise denoising.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->