### PR TITLE
feat(dsp): replace OpenMP with internal worker pool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,7 @@ jobs:
             cmake \
             gcovr \
             libfftw3-dev \
-            libsndfile1-dev \
-            libomp-dev
+            libsndfile1-dev
 
       - name: Configure build
         run: |
@@ -55,7 +54,8 @@ jobs:
       - name: Generate coverage report
         if: matrix.config.run_coverage
         run: |
-          gcovr --xml build/coverage.xml -r . -e tests/ -e examples/
+          gcovr --xml build/coverage.xml -r . -e tests/ -e examples/ \
+            --gcov-ignore-parse-errors negative_hits.warn_once_per_file
 
       - name: Upload coverage to Codecov
         if: matrix.config.run_coverage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,8 +40,7 @@ jobs:
             clang-tools \
             cmake \
             libfftw3-dev \
-            libsndfile1-dev \
-            libomp-dev
+            libsndfile1-dev
 
       - name: Configure build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.2] - Unreleased
 
 ### Added
+- **Internal Thread Pool**: Added `SbThreadPool` (`src/shared/utils/thread_pool.h`), a fixed-size worker pool with semaphore-based dispatch and static contiguous partitioning, powering multi-threaded NLM 2D smoothing without any external threading runtime. Thread count is configurable per instance via `NlmFilterConfig::num_threads` (default `NLM_NUM_THREADS_DEFAULT`).
 
 ### Improved & Refactored
+- **OpenMP Removal**: Replaced OpenMP parallelization in the NLM 2D filter with the internal worker pool. Binaries no longer depend on `libomp`/`libgomp`/`libomp140` runtimes, dispatches are deterministic (static partitioning instead of dynamic scheduling), and no threads or locks are created in the audio path.
 - **Adaptive Profile Persistence**: Updated standalone adaptive noise estimation to persist learned noise profiles to the noise profile manager so estimated spectral curves remain available when switching to manual mode.
 - **Manual Baseline Re-seeding**: Fixed standalone adaptive mode state tracking to reset hybrid initialization state when no manual profile exists, ensuring manual noise profiles captured while adaptive mode is active immediately morph and seed the baseline floor.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,49 +46,13 @@ else()
 endif()
 
 # ==============================================================================
-# 2. Math & OpenMP Dependencies
+# 2. Math & Threading Dependencies
 # ==============================================================================
 find_library(MATH_LIB m)
 
-if(APPLE)
-    list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/libomp" "/usr/local/opt/libomp")
-endif()
-
-find_package(OpenMP QUIET)
-if(MSVC AND OpenMP_C_FOUND)
-    set_target_properties(OpenMP::OpenMP_C PROPERTIES
-        INTERFACE_COMPILE_OPTIONS "/openmp:llvm"
-    )
-elseif(NOT OpenMP_C_FOUND)
-    message(STATUS "OpenMP not found. Searching Homebrew paths...")
-    find_path(OMP_INCLUDE_DIR omp.h HINTS /opt/homebrew/opt/libomp/include /usr/local/opt/libomp/include)
-    find_library(OMP_LIB NAMES omp gomp HINTS /opt/homebrew/opt/libomp/lib /usr/local/opt/libomp/lib)
-    if(OMP_LIB AND OMP_INCLUDE_DIR)
-        add_library(OpenMP::OpenMP_C INTERFACE IMPORTED)
-        if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND APPLE)
-            message(STATUS "OpenMP found: ${OMP_LIB}")
-            set_target_properties(OpenMP::OpenMP_C PROPERTIES
-                INTERFACE_COMPILE_OPTIONS "-Xpreprocessor;-fopenmp"
-                INTERFACE_INCLUDE_DIRECTORIES "${OMP_INCLUDE_DIR}"
-                INTERFACE_LINK_LIBRARIES "${OMP_LIB}"
-            )
-        else()
-
-            set_target_properties(OpenMP::OpenMP_C PROPERTIES
-                INTERFACE_COMPILE_OPTIONS "-fopenmp"
-                INTERFACE_INCLUDE_DIRECTORIES "${OMP_INCLUDE_DIR}"
-                INTERFACE_LINK_LIBRARIES "${OMP_LIB}"
-            )
-        endif()
-        set(OpenMP_C_FOUND TRUE)
-    endif()
-endif()
-
-if(OpenMP_C_FOUND OR TARGET OpenMP::OpenMP_C)
-    message(STATUS "OpenMP: ENABLED (Multi-threaded NLM 2D filter enabled)")
-else()
-    message(WARNING "OpenMP: NOT FOUND (NLM 2D filter will run single-threaded)")
-endif()
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+message(STATUS "Threading: internal worker pool via ${Threads_LIBRARIES}")
 
 # ==============================================================================
 # 3. Optional Dependencies (Examples & Tests)
@@ -160,11 +124,7 @@ if(MATH_LIB)
 endif()
 
 # FFTW is an internal implementation detail (not exposed in public headers) -> PRIVATE
-target_link_libraries(libspecbleach PRIVATE ${FFTW_TARGET})
-
-if(OpenMP_C_FOUND OR TARGET OpenMP::OpenMP_C)
-    target_link_libraries(libspecbleach PRIVATE OpenMP::OpenMP_C)
-endif()
+target_link_libraries(libspecbleach PRIVATE ${FFTW_TARGET} Threads::Threads)
 
 # AVX SIMD Target
 if(ENABLE_AVX)
@@ -178,9 +138,6 @@ if(ENABLE_AVX)
         endif()
         target_include_directories(specbleach_avx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
         target_link_libraries(specbleach_avx PRIVATE ${FFTW_TARGET})
-        if(OpenMP_C_FOUND OR TARGET OpenMP::OpenMP_C)
-            target_link_libraries(specbleach_avx PRIVATE OpenMP::OpenMP_C)
-        endif()
         target_link_libraries(libspecbleach PRIVATE specbleach_avx)
     endif()
 endif()
@@ -237,6 +194,7 @@ if(ENABLE_TESTS)
     add_specbleach_test(test_noise_floor_manager "test_noise_floor_manager.c")
     add_specbleach_test(test_adaptive_noise_estimator "test_adaptive_noise_estimator.c")
     add_specbleach_test(test_nlm_filter "test_nlm_filter.c")
+    add_specbleach_test(test_thread_pool "test_thread_pool.c")
     add_specbleach_test(test_specbleach_2d_denoiser "test_specbleach_2d_denoiser.c")
     add_specbleach_test(test_suppression_engine "test_suppression_engine.c")
     add_specbleach_test(test_masking_veto "test_masking_veto.c")
@@ -311,11 +269,6 @@ if(SPECBLEACH_INSTALL)
         set(PKG_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
     else()
         set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-    endif()
-
-    set(PKG_CONFIG_OPENMP_FLAGS "")
-    if(OpenMP_C_FOUND)
-        set(PKG_CONFIG_OPENMP_FLAGS "${OpenMP_C_FLAGS}")
     endif()
 
     configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,11 @@ if(SPECBLEACH_INSTALL)
         set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
     endif()
 
+    set(PKG_CONFIG_LIBS_PRIVATE "-lm")
+    if(CMAKE_THREAD_LIBS_INIT)
+        string(APPEND PKG_CONFIG_LIBS_PRIVATE " ${CMAKE_THREAD_LIBS_INIT}")
+    endif()
+
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/specbleach.pc.in"
         "${CMAKE_CURRENT_BINARY_DIR}/specbleach.pc"

--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ To compile and install `libspecbleach`, you will need:
 - [CMake](https://cmake.org/) (3.16 or newer)
 - `pkg-config` (required when `USE_SYSTEM_FFTW=ON`)
 - [FFTW3](http://www.fftw.org/) library (`libfftw3f`, or let CMake fetch it automatically)
-- [OpenMP](https://www.openmp.org/) for parallel processing (recommended for multi-threaded NLM 2D denoising):
-  - **macOS**: `brew install libomp`
-  - **Linux**: `sudo apt install libomp-dev` (Clang) or included with GCC
-  - **Windows**: Included natively in MSVC (`/openmp`) and MinGW GCC (`-fopenmp`)
+- A threading library (pthreads on POSIX; built-in on Windows)
 - [libsndfile](https://github.com/libsndfile/libsndfile) (optional, for test suite and demo tools)
 
 ## Installation
@@ -96,14 +93,9 @@ You can configure the build using `-Doption=VALUE`:
 
 
 > [!IMPORTANT]
-> **Critical Performance Note for Packagers & Users**: The advanced "2D Denoising" (NLM) feature is computationally intensive and relies heavily on SIMD vectorization and **multi-core parallelization via OpenMP**.
+> **Performance Note for Packagers & Users**: The advanced "2D Denoising" (NLM) feature is computationally intensive and relies heavily on SIMD vectorization and multi-core parallelization through a **built-in worker pool** (no external threading runtime required).
 >
-> If OpenMP is missing at build time, NLM will fall back to single-threaded processing, which may cause high CPU utilization and audio dropouts (xruns) in real-time DAW environments.
->
-> Always ensure OpenMP runtime libraries are installed prior to running CMake:
-> - **macOS**: `brew install libomp`
-> - **Linux (Ubuntu/Debian)**: `sudo apt install libomp-dev`
-> - **Windows**: OpenMP is built into MSVC and MinGW GCC.
+> The pool is created during `specbleach_2d_initialize` and dispatches work with static, contiguous partitioning, keeping output deterministic across runs. Thread count defaults to 4 (see `NLM_NUM_THREADS_DEFAULT` in `src/shared/configurations.h`) and can be tuned per instance through `NlmFilterConfig::num_threads`.
 >
 > You **MUST** configure with `-DCMAKE_BUILD_TYPE=Release` (or the compiler's equivalent optimization settings) for real-time performance. Debug or unoptimized builds will result in high CPU load.
 

--- a/specbleach.pc.in
+++ b/specbleach.pc.in
@@ -8,5 +8,5 @@ Description: C library for audio noise reduction and spectral processing
 Version: @PKG_CONFIG_VERSION@
 Requires.private: @PKG_CONFIG_REQUIRES_PRIVATE@
 Libs: -L${libdir} -lspecbleach
-Libs.private: -lm
+Libs.private: @PKG_CONFIG_LIBS_PRIVATE@
 Cflags: -I${includedir}

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -211,6 +211,7 @@ _Static_assert(sizeof(uint32_t) == 4, "uint32_t must be exactly 32 bits");
 #define NLM_SNR_NOISE_FLOOR_MIN 1e-9F
 #define NLM_DISTANCE_THRESHOLD_MULTIPLIER 4.0F
 #define NLM_NUM_THREADS_DEFAULT 4U
+#define NLM_MAX_THREADS 16U
 
 // Must be >= search_time_past + search_time_future + patch_size for NLM caching
 // Using power-of-two (64U) for efficient modulo wrap-around and future headroom

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -210,6 +210,7 @@ _Static_assert(sizeof(uint32_t) == 4, "uint32_t must be exactly 32 bits");
 #define NLM_MIN_WEIGHT 1e-10F
 #define NLM_SNR_NOISE_FLOOR_MIN 1e-9F
 #define NLM_DISTANCE_THRESHOLD_MULTIPLIER 4.0F
+#define NLM_NUM_THREADS_DEFAULT 4U
 
 // Must be >= search_time_past + search_time_future + patch_size for NLM caching
 // Using power-of-two (64U) for efficient modulo wrap-around and future headroom

--- a/src/shared/denoiser_logic/processing/nlm_filter.c
+++ b/src/shared/denoiser_logic/processing/nlm_filter.c
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "shared/configurations.h"
 #include "shared/denoiser_logic/processing/nlm_filter_internal.h"
 #include "shared/utils/simd_utils.h"
+#include "shared/utils/thread_pool.h"
 
 NlmFilter* nlm_filter_initialize(NlmFilterConfig config) {
   if (config.spectrum_size == 0) {
@@ -74,16 +75,18 @@ NlmFilter* nlm_filter_initialize(NlmFilterConfig config) {
 
   self->target_frame_offset = self->config.search_range_time_past;
 
-  self->num_threads = 4;
-#ifdef _OPENMP
-  const char* omp_env = getenv("OMP_NUM_THREADS");
-  if (omp_env) {
-    int val = atoi(omp_env);
-    if (val > 0) {
-      self->num_threads = (uint32_t)val;
+  self->num_threads = self->config.num_threads > 0U ? self->config.num_threads
+                                                    : NLM_NUM_THREADS_DEFAULT;
+  if (self->num_threads > 1U) {
+    // The calling thread participates in every dispatch, so the pool only
+    // needs num_threads - 1 dedicated workers.
+    self->pool = sb_thread_pool_create(self->num_threads - 1U);
+    if (!self->pool) {
+      self->num_threads = 1U; // Graceful fallback to sequential processing
     }
+  } else {
+    self->num_threads = 1U;
   }
-#endif
 
   self->frame_buffer =
       (float**)calloc(self->config.time_buffer_size, sizeof(float*));
@@ -151,6 +154,9 @@ void nlm_filter_free(NlmFilter* filter) {
   if (filter->frame_ptrs) {
     free((void*)filter->frame_ptrs);
   }
+
+  sb_thread_pool_free(filter->pool);
+  filter->pool = NULL;
 
   free(filter);
 }

--- a/src/shared/denoiser_logic/processing/nlm_filter.c
+++ b/src/shared/denoiser_logic/processing/nlm_filter.c
@@ -77,6 +77,9 @@ NlmFilter* nlm_filter_initialize(NlmFilterConfig config) {
 
   self->num_threads = self->config.num_threads > 0U ? self->config.num_threads
                                                     : NLM_NUM_THREADS_DEFAULT;
+  if (self->num_threads > NLM_MAX_THREADS) {
+    self->num_threads = NLM_MAX_THREADS;
+  }
   if (self->num_threads > 1U) {
     // The calling thread participates in every dispatch, so the pool only
     // needs num_threads - 1 dedicated workers.

--- a/src/shared/denoiser_logic/processing/nlm_filter.h
+++ b/src/shared/denoiser_logic/processing/nlm_filter.h
@@ -49,6 +49,9 @@ typedef struct NlmFilterConfig {
                                           decay */
   float distance_threshold;          /**< Skip patches with distance >
                                           threshold (default: 4*h²) */
+  uint32_t num_threads;              /**< Total threads executing the NLM
+                                          smoothing (caller included). Zero
+                                          uses NLM_NUM_THREADS_DEFAULT */
 } NlmFilterConfig;
 
 /**

--- a/src/shared/denoiser_logic/processing/nlm_filter_internal.h
+++ b/src/shared/denoiser_logic/processing/nlm_filter_internal.h
@@ -25,19 +25,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "shared/denoiser_logic/processing/nlm_filter.h"
 #include "shared/utils/general_utils.h"
 #include "shared/utils/simd_utils.h"
+#include "shared/utils/thread_pool.h"
 #include <float.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-
-#ifdef _OPENMP
-#include <omp.h>
-#define SB_HAS_OPENMP 1
-#else
-#define SB_HAS_OPENMP 0
-#endif
 
 typedef bool (*nlm_process_impl_fn)(NlmFilter* filter, float* smoothed_snr);
 
@@ -69,7 +63,11 @@ struct NlmFilter {
   // Function pointer for runtime architecture dispatch
   nlm_process_impl_fn process_fn;
 
-  // Number of threads for parallel processing
+  // Preallocated worker pool for the NLM smoothing loop (NULL if
+  // single-threaded)
+  SbThreadPool* pool;
+
+  // Number of threads executing the smoothing loop (caller included)
   uint32_t num_threads;
 };
 
@@ -171,17 +169,25 @@ static inline SB_UNUSED float compute_patch_distance(NlmFilter* self,
   return distance;
 }
 
-static inline SB_UNUSED bool nlm_filter_process_core(NlmFilter* filter,
-                                                     float* smoothed_snr) {
-  if (!filter || !smoothed_snr) {
-    return false;
-  }
+// Context for the block-smoothing loop. Every block accumulates into a
+// disjoint range of smoothed_snr/weight_sum, so contiguous static partitioning
+// is race-free and produces the same per-bin accumulation order (and therefore
+// the same output) as sequential execution.
+typedef struct {
+  NlmFilter* filter;
+  float* smoothed_snr;
+  float* weight_sum;
+  float* target_frame;
+} NlmBlockTask;
 
-  if (!nlm_filter_is_ready(filter)) {
-    return false;
-  }
-
-  sb_simd_state_t old_simd_state = sb_simd_enable_ftz_daz();
+static inline SB_UNUSED void nlm_process_block_range(void* raw_ctx,
+                                                     uint32_t first_block,
+                                                     uint32_t block_count) {
+  const NlmBlockTask* ctx = (const NlmBlockTask*)raw_ctx;
+  NlmFilter* filter = ctx->filter;
+  float* smoothed_snr = ctx->smoothed_snr;
+  float* weight_sum = ctx->weight_sum;
+  const float* target_frame = ctx->target_frame;
 
   const uint32_t spectrum_size = filter->config.spectrum_size;
   const uint32_t paste_size = filter->config.paste_block_size;
@@ -190,28 +196,13 @@ static inline SB_UNUSED bool nlm_filter_process_core(NlmFilter* filter,
       (int32_t)filter->config.search_range_time_past;
   const int32_t search_time_future =
       (int32_t)filter->config.search_range_time_future;
+  const float current_inv_h2 = filter->inv_h_squared;
+  const float current_dist_threshold = filter->distance_threshold_actual;
+  const uint32_t patch_size = filter->config.patch_size;
+  const uint32_t half_patch_size = patch_size / 2;
 
-  populate_frame_ptrs(filter);
-
-  float* target_frame = cached_get_frame(filter, 0);
-
-  if (filter->config.h_parameter <= 0.0F || filter->h_squared <= 0.0F) {
-    memcpy(smoothed_snr, target_frame, spectrum_size * sizeof(float));
-    sb_simd_restore_state(old_simd_state);
-    return true;
-  }
-
-  memset(smoothed_snr, 0, spectrum_size * sizeof(float));
-
-  float* weight_sum = filter->weight_accum;
-  memset(weight_sum, 0, spectrum_size * sizeof(float));
-
-  uint32_t block_start = 0;
-#if SB_HAS_OPENMP
-#pragma omp parallel for schedule(dynamic) num_threads(filter->num_threads)
-#endif
-  for (block_start = 0; block_start < spectrum_size;
-       block_start += paste_size) {
+  for (uint32_t block = 0; block < block_count; block++) {
+    const uint32_t block_start = (first_block + block) * paste_size;
 
     uint32_t block_center = block_start + (paste_size / 2);
     if (block_center >= spectrum_size) {
@@ -231,12 +222,7 @@ static inline SB_UNUSED bool nlm_filter_process_core(NlmFilter* filter,
       continue;
     }
 
-    float current_inv_h2 = filter->inv_h_squared;
-    float current_dist_threshold = filter->distance_threshold_actual;
-
     sb_vec8_t target_vecs[8];
-    const uint32_t patch_size = filter->config.patch_size;
-    const uint32_t half_patch_size = patch_size / 2;
 
     bool safe_block = (block_center >= half_patch_size) &&
                       (block_center + half_patch_size <= spectrum_size);
@@ -308,6 +294,47 @@ static inline SB_UNUSED bool nlm_filter_process_core(NlmFilter* filter,
         }
       }
     }
+  }
+}
+
+static inline SB_UNUSED bool nlm_filter_process_core(NlmFilter* filter,
+                                                     float* smoothed_snr) {
+  if (!filter || !smoothed_snr) {
+    return false;
+  }
+
+  if (!nlm_filter_is_ready(filter)) {
+    return false;
+  }
+
+  sb_simd_state_t old_simd_state = sb_simd_enable_ftz_daz();
+
+  const uint32_t spectrum_size = filter->config.spectrum_size;
+  const uint32_t paste_size = filter->config.paste_block_size;
+
+  populate_frame_ptrs(filter);
+
+  float* target_frame = cached_get_frame(filter, 0);
+
+  if (filter->config.h_parameter <= 0.0F || filter->h_squared <= 0.0F) {
+    memcpy(smoothed_snr, target_frame, spectrum_size * sizeof(float));
+    sb_simd_restore_state(old_simd_state);
+    return true;
+  }
+
+  memset(smoothed_snr, 0, spectrum_size * sizeof(float));
+
+  float* weight_sum = filter->weight_accum;
+  memset(weight_sum, 0, spectrum_size * sizeof(float));
+
+  NlmBlockTask task_ctx = {filter, smoothed_snr, weight_sum, target_frame};
+  const uint32_t num_blocks = (spectrum_size + paste_size - 1) / paste_size;
+
+  if (filter->pool) {
+    sb_thread_pool_parallel_for(filter->pool, num_blocks,
+                                nlm_process_block_range, &task_ctx);
+  } else {
+    nlm_process_block_range(&task_ctx, 0, num_blocks);
   }
 
   for (uint32_t k = 0; k < spectrum_size; k++) {

--- a/src/shared/utils/simd_utils.h
+++ b/src/shared/utils/simd_utils.h
@@ -421,6 +421,7 @@ SB_SIMD_INLINE sb_vec8_t sb_sqrt8(sb_vec8_t a) {
 #else
   sb_vec8_t r;
   float32x4_t zero = vdupq_n_f32(0.0f);
+  // cppcheck-suppress duplicateExpression ; intentional NaN (0/0)
   float32x4_t nan_val = vdupq_n_f32(0.0f / 0.0f);
 
   // Process a.v1

--- a/src/shared/utils/thread_pool.c
+++ b/src/shared/utils/thread_pool.c
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "thread_pool.h"
 
 #include <stdatomic.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 #include "simd_utils.h"

--- a/src/shared/utils/thread_pool.c
+++ b/src/shared/utils/thread_pool.c
@@ -73,6 +73,7 @@ struct SbThreadPool {
 
   uint32_t worker_count;
   uint32_t threads_created;
+  uint32_t semaphores_initialized; // Workers with a live semaphore
   SbWorker* workers;
 #ifdef _WIN32
   HANDLE* threads;
@@ -213,6 +214,7 @@ SbThreadPool* sb_thread_pool_create(uint32_t num_workers) {
       return NULL;
     }
 #endif
+    pool->semaphores_initialized++;
   }
 
   for (uint32_t i = 0U; i < num_workers; i++) {
@@ -299,7 +301,7 @@ void sb_thread_pool_free(SbThreadPool* pool) {
   }
 
   if (pool->workers) {
-    for (uint32_t i = 0U; i < pool->worker_count; i++) {
+    for (uint32_t i = 0U; i < pool->semaphores_initialized; i++) {
 #ifdef _WIN32
       if (pool->workers[i].sem) {
         CloseHandle(pool->workers[i].sem);

--- a/src/shared/utils/thread_pool.c
+++ b/src/shared/utils/thread_pool.c
@@ -1,0 +1,318 @@
+/*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "thread_pool.h"
+
+#include <stdatomic.h>
+#include <stdlib.h>
+
+#include "simd_utils.h"
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <process.h>
+#include <windows.h>
+#elif defined(__APPLE__)
+// macOS does not implement unnamed POSIX semaphores (sem_init fails with
+// ENOSYS); Grand Central Dispatch semaphores are the native equivalent.
+#include <dispatch/dispatch.h>
+#include <pthread.h>
+#include <sched.h>
+#else
+#include <pthread.h>
+#include <sched.h>
+#include <semaphore.h>
+#endif
+
+// Each worker owns a private semaphore: every dispatch posts exactly one
+// token per participating worker, so wakeups are exactly-once and a worker
+// can never steal another worker's dispatch.
+typedef struct {
+  SbThreadPool* pool;
+  uint32_t participant; // Range index: caller is 0, workers are 1..N
+#ifdef _WIN32
+  HANDLE sem;
+#elif defined(__APPLE__)
+  dispatch_semaphore_t sem;
+#else
+  sem_t sem;
+#endif
+} SbWorker;
+
+typedef struct {
+  void (*task)(void* arg, uint32_t start, uint32_t count);
+  void* arg;
+  uint32_t num_items;
+  uint32_t base_count;   // Minimum range size per participant
+  uint32_t remainder;    // First `remainder` participants get one extra item
+  uint32_t participants; // Ranges executed per dispatch (caller included)
+} SbWorkItem;
+
+struct SbThreadPool {
+  atomic_uint remaining; // Workers that have not finished the current dispatch
+  atomic_bool shutdown;  // Set once on destruction
+  SbWorkItem work;       // Published to workers via semaphore synchronization
+
+  uint32_t worker_count;
+  uint32_t threads_created;
+  SbWorker* workers;
+#ifdef _WIN32
+  HANDLE* threads;
+#else
+  pthread_t* threads;
+#endif
+};
+
+static void sb_yield_cpu(void) {
+#ifdef _WIN32
+  SwitchToThread();
+#else
+  sched_yield();
+#endif
+}
+
+static inline void sb_wake_worker(SbWorker* worker) {
+#ifdef _WIN32
+  ReleaseSemaphore(worker->sem, 1, NULL);
+#elif defined(__APPLE__)
+  dispatch_semaphore_signal(worker->sem);
+#else
+  sem_post(&worker->sem);
+#endif
+}
+
+static inline void sb_worker_wait(SbWorker* worker) {
+#ifdef _WIN32
+  WaitForSingleObject(worker->sem, INFINITE);
+#elif defined(__APPLE__)
+  dispatch_semaphore_wait(worker->sem, DISPATCH_TIME_FOREVER);
+#else
+  while (sem_wait(&worker->sem) != 0) {
+    // Retry: sem_wait only fails here with EINTR
+  }
+#endif
+}
+
+static inline uint32_t sb_range_start(uint32_t p, uint32_t base_count,
+                                      uint32_t remainder) {
+  return p * base_count + (p < remainder ? p : remainder);
+}
+
+static inline uint32_t sb_range_count(uint32_t base_count, uint32_t has_extra) {
+  return base_count + has_extra;
+}
+
+static void sb_worker_execute(SbWorker* worker) {
+  SbThreadPool* pool = worker->pool;
+  const uint32_t count =
+      sb_range_count(pool->work.base_count,
+                     (worker->participant < pool->work.remainder) ? 1U : 0U);
+  const uint32_t start = sb_range_start(
+      worker->participant, pool->work.base_count, pool->work.remainder);
+  if (count > 0U && start + count <= pool->work.num_items) {
+    pool->work.task(pool->work.arg, start, count);
+  }
+  atomic_fetch_sub_explicit(&pool->remaining, 1U, memory_order_acq_rel);
+}
+
+#ifdef _WIN32
+static unsigned __stdcall sb_worker_main(void* raw) {
+#else
+static void* sb_worker_main(void* raw) {
+#endif
+  SbWorker* worker = (SbWorker*)raw;
+
+  // Dedicated library threads run with denormals flushed for their lifetime.
+  sb_simd_enable_ftz_daz();
+
+  for (;;) {
+    sb_worker_wait(worker);
+    if (atomic_load_explicit(&worker->pool->shutdown, memory_order_acquire)) {
+      break;
+    }
+    sb_worker_execute(worker);
+  }
+
+#ifdef _WIN32
+  return 0U;
+#else
+  return NULL;
+#endif
+}
+
+static inline int sb_worker_spawn(SbThreadPool* pool, uint32_t index) {
+#ifdef _WIN32
+  const uintptr_t handle =
+      _beginthreadex(NULL, 0U, sb_worker_main, &pool->workers[index], 0U, NULL);
+  pool->threads[index] = (HANDLE)handle;
+  return pool->threads[index] ? 0 : -1;
+#else
+  return pthread_create(&pool->threads[index], NULL, sb_worker_main,
+                        &pool->workers[index]);
+#endif
+}
+
+SbThreadPool* sb_thread_pool_create(uint32_t num_workers) {
+  if (num_workers == 0U) {
+    return NULL;
+  }
+
+  SbThreadPool* pool = (SbThreadPool*)calloc(1U, sizeof(SbThreadPool));
+  if (!pool) {
+    return NULL;
+  }
+
+  atomic_init(&pool->remaining, 0U);
+  atomic_init(&pool->shutdown, false);
+  pool->worker_count = num_workers;
+
+  pool->workers = (SbWorker*)calloc(num_workers, sizeof(SbWorker));
+  pool->threads = (void*)calloc(num_workers, sizeof(*pool->threads));
+  if (!pool->workers || !pool->threads) {
+    sb_thread_pool_free(pool);
+    return NULL;
+  }
+
+  for (uint32_t i = 0U; i < num_workers; i++) {
+    SbWorker* worker = &pool->workers[i];
+    worker->pool = pool;
+    worker->participant = i + 1U;
+#ifdef _WIN32
+    worker->sem = CreateSemaphore(NULL, 0, 1, NULL);
+    if (!worker->sem) {
+      sb_thread_pool_free(pool);
+      return NULL;
+    }
+#elif defined(__APPLE__)
+    worker->sem = dispatch_semaphore_create(0);
+    if (!worker->sem) {
+      sb_thread_pool_free(pool);
+      return NULL;
+    }
+#else
+    if (sem_init(&worker->sem, 0, 0U) != 0) {
+      sb_thread_pool_free(pool);
+      return NULL;
+    }
+#endif
+  }
+
+  for (uint32_t i = 0U; i < num_workers; i++) {
+    if (sb_worker_spawn(pool, i) != 0) {
+      sb_thread_pool_free(pool);
+      return NULL;
+    }
+    pool->threads_created++;
+  }
+
+  return pool;
+}
+
+uint32_t sb_thread_pool_num_workers(const SbThreadPool* pool) {
+  return pool ? pool->worker_count : 0U;
+}
+
+void sb_thread_pool_parallel_for(SbThreadPool* pool, uint32_t num_items,
+                                 void (*task)(void* arg, uint32_t start,
+                                              uint32_t count),
+                                 void* arg) {
+  if (!pool || num_items == 0U || !task) {
+    if (task && num_items > 0U) {
+      task(arg, 0U, num_items);
+    }
+    return;
+  }
+
+  // Caller plus workers; never more participants than items.
+  uint32_t participants = pool->worker_count + 1U;
+  if (participants > num_items) {
+    participants = num_items;
+  }
+  const uint32_t workers = participants - 1U;
+  const uint32_t base_count = num_items / participants;
+  const uint32_t remainder = num_items - base_count * participants;
+
+  pool->work.task = task;
+  pool->work.arg = arg;
+  pool->work.num_items = num_items;
+  pool->work.base_count = base_count;
+  pool->work.remainder = remainder;
+  pool->work.participants = participants;
+
+  atomic_store_explicit(&pool->remaining, workers, memory_order_relaxed);
+
+  // Semaphore synchronization publishes the work item above to every woken
+  // worker. Each worker owns a private token, so exactly `workers` distinct
+  // workers execute exactly once.
+  for (uint32_t i = 0U; i < workers; i++) {
+    sb_wake_worker(&pool->workers[i]);
+  }
+
+  // The caller executes the first range, then joins the workers.
+  const uint32_t caller_count =
+      sb_range_count(base_count, (remainder > 0U) ? 1U : 0U);
+  if (caller_count > 0U) {
+    task(arg, 0U, caller_count);
+  }
+
+  while (atomic_load_explicit(&pool->remaining, memory_order_acquire) != 0U) {
+    sb_yield_cpu();
+  }
+}
+
+void sb_thread_pool_free(SbThreadPool* pool) {
+  if (!pool) {
+    return;
+  }
+
+  if (pool->threads) {
+    atomic_store_explicit(&pool->shutdown, true, memory_order_release);
+    for (uint32_t i = 0U; i < pool->threads_created; i++) {
+      sb_wake_worker(&pool->workers[i]);
+    }
+    for (uint32_t i = 0U; i < pool->threads_created; i++) {
+#ifdef _WIN32
+      WaitForSingleObject(pool->threads[i], INFINITE);
+      CloseHandle(pool->threads[i]);
+#else
+      pthread_join(pool->threads[i], NULL);
+#endif
+    }
+  }
+
+  for (uint32_t i = 0U; i < pool->worker_count; i++) {
+#ifdef _WIN32
+    if (pool->workers[i].sem) {
+      CloseHandle(pool->workers[i].sem);
+    }
+#elif defined(__APPLE__)
+    if (pool->workers[i].sem) {
+      dispatch_release(pool->workers[i].sem);
+    }
+#else
+    sem_destroy(&pool->workers[i].sem);
+#endif
+  }
+
+  free(pool->workers);
+  free(pool->threads);
+  free(pool);
+}

--- a/src/shared/utils/thread_pool.c
+++ b/src/shared/utils/thread_pool.c
@@ -283,7 +283,7 @@ void sb_thread_pool_free(SbThreadPool* pool) {
     return;
   }
 
-  if (pool->threads) {
+  if (pool->threads && pool->workers) {
     atomic_store_explicit(&pool->shutdown, true, memory_order_release);
     for (uint32_t i = 0U; i < pool->threads_created; i++) {
       sb_wake_worker(&pool->workers[i]);
@@ -298,18 +298,20 @@ void sb_thread_pool_free(SbThreadPool* pool) {
     }
   }
 
-  for (uint32_t i = 0U; i < pool->worker_count; i++) {
+  if (pool->workers) {
+    for (uint32_t i = 0U; i < pool->worker_count; i++) {
 #ifdef _WIN32
-    if (pool->workers[i].sem) {
-      CloseHandle(pool->workers[i].sem);
-    }
+      if (pool->workers[i].sem) {
+        CloseHandle(pool->workers[i].sem);
+      }
 #elif defined(__APPLE__)
-    if (pool->workers[i].sem) {
-      dispatch_release(pool->workers[i].sem);
-    }
+      if (pool->workers[i].sem) {
+        dispatch_release(pool->workers[i].sem);
+      }
 #else
-    sem_destroy(&pool->workers[i].sem);
+      sem_destroy(&pool->workers[i].sem);
 #endif
+    }
   }
 
   free(pool->workers);

--- a/src/shared/utils/thread_pool.h
+++ b/src/shared/utils/thread_pool.h
@@ -21,7 +21,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef SHARED_UTILS_THREAD_POOL_H
 #define SHARED_UTILS_THREAD_POOL_H
 
-#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -59,9 +58,10 @@ uint32_t sb_thread_pool_num_workers(const SbThreadPool* pool);
  * contiguous ranges.
  *
  * The calling thread executes the first range synchronously and joins the
- * workers before returning, so on return all items are fully processed. When
- * the pool is NULL, `num_items` is zero, or there is a single range, the task
- * runs sequentially on the calling thread.
+ * workers before returning, so on return all items are fully processed. If
+ * `num_items` is zero, the function returns without invoking the task. When
+ * the pool is NULL or there is a single range, the task runs sequentially on
+ * the calling thread.
  */
 void sb_thread_pool_parallel_for(SbThreadPool* pool, uint32_t num_items,
                                  void (*task)(void* arg, uint32_t start,

--- a/src/shared/utils/thread_pool.h
+++ b/src/shared/utils/thread_pool.h
@@ -1,0 +1,80 @@
+/*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef SHARED_UTILS_THREAD_POOL_H
+#define SHARED_UTILS_THREAD_POOL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Fixed-size worker pool for deterministic fork/join parallel loops.
+ *
+ * Workers are created once at pool creation and block between dispatches, so
+ * dispatching from a real-time audio thread performs no allocation, no lock
+ * acquisition, and no thread management. Work is split into contiguous static
+ * ranges, which keeps the per-element accumulation order identical to
+ * single-threaded execution.
+ */
+typedef struct SbThreadPool SbThreadPool;
+
+/**
+ * @brief Creates a pool with the specified number of worker threads.
+ *
+ * The calling thread always participates in work execution, so the effective
+ * parallelism of a dispatch is `num_workers + 1`. Returns NULL on failure or
+ * if `num_workers` is zero; callers should fall back to sequential execution.
+ */
+SbThreadPool* sb_thread_pool_create(uint32_t num_workers);
+
+/**
+ * @brief Returns the number of worker threads in the pool (excludes the
+ * calling thread).
+ */
+uint32_t sb_thread_pool_num_workers(const SbThreadPool* pool);
+
+/**
+ * @brief Runs `task(arg, start, count)` over `[0, num_items)` split into
+ * contiguous ranges.
+ *
+ * The calling thread executes the first range synchronously and joins the
+ * workers before returning, so on return all items are fully processed. When
+ * the pool is NULL, `num_items` is zero, or there is a single range, the task
+ * runs sequentially on the calling thread.
+ */
+void sb_thread_pool_parallel_for(SbThreadPool* pool, uint32_t num_items,
+                                 void (*task)(void* arg, uint32_t start,
+                                              uint32_t count),
+                                 void* arg);
+
+/**
+ * @brief Stops all workers and releases the pool. Passing NULL is a no-op.
+ */
+void sb_thread_pool_free(SbThreadPool* pool);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHARED_UTILS_THREAD_POOL_H */

--- a/tests/test_nlm_filter.c
+++ b/tests/test_nlm_filter.c
@@ -439,26 +439,35 @@ void test_nlm_filter_process_patch8(void) {
   printf("✓ NLM filter patch_size=8 process tests passed\n");
 }
 
-void test_nlm_filter_omp_config(void) {
-  printf("Testing NLM filter OpenMP configuration...\n");
-
-  // Set OMP_NUM_THREADS env var
-  setenv("OMP_NUM_THREADS", "2", 1);
+void test_nlm_filter_thread_config(void) {
+  printf("Testing NLM filter threading configuration...\n");
 
   NlmFilterConfig config = {.spectrum_size = 32};
   NlmFilter* filter = nlm_filter_initialize(config);
   TEST_ASSERT(filter != NULL, "Initialization failed");
-
-  // On many platforms this will trigger the env-reading logic in nlm_filter.c
-  TEST_ASSERT(filter->num_threads == 2,
-              "Filter should respect OMP_NUM_THREADS env var");
-
+  TEST_ASSERT(filter->num_threads == NLM_NUM_THREADS_DEFAULT,
+              "Zero thread count should fall back to default");
   nlm_filter_free(filter);
 
-  // Clean up
-  unsetenv("OMP_NUM_THREADS");
+  NlmFilterConfig single_config = {.spectrum_size = 32, .num_threads = 1};
+  NlmFilter* single_filter = nlm_filter_initialize(single_config);
+  TEST_ASSERT(single_filter != NULL, "Single-threaded initialization failed");
+  TEST_ASSERT(single_filter->num_threads == 1U, "Thread count should be 1");
+  TEST_ASSERT(single_filter->pool == NULL,
+              "Single-threaded filter should not create a worker pool");
+  nlm_filter_free(single_filter);
 
-  printf("✓ NLM filter OpenMP configuration tests passed\n");
+  NlmFilterConfig multi_config = {.spectrum_size = 32, .num_threads = 3};
+  NlmFilter* multi_filter = nlm_filter_initialize(multi_config);
+  TEST_ASSERT(multi_filter != NULL, "Multi-threaded initialization failed");
+  TEST_ASSERT(multi_filter->num_threads == 3U, "Thread count should be 3");
+  TEST_ASSERT(multi_filter->pool != NULL,
+              "Multi-threaded filter should create a worker pool");
+  TEST_ASSERT(sb_thread_pool_num_workers(multi_filter->pool) == 2U,
+              "Pool should have num_threads - 1 workers");
+  nlm_filter_free(multi_filter);
+
+  printf("✓ NLM filter threading configuration tests passed\n");
 }
 
 void test_nlm_filter_snr_and_reconstruct(void) {
@@ -557,7 +566,7 @@ int main(void) {
   test_nlm_filter_null_handling();
   test_nlm_filter_snr_and_reconstruct();
   test_nlm_filter_frame_cache();
-  test_nlm_filter_omp_config();
+  test_nlm_filter_thread_config();
 
   printf("\n✅ All NLM filter tests passed!\n");
   return 0;

--- a/tests/test_thread_pool.c
+++ b/tests/test_thread_pool.c
@@ -1,0 +1,150 @@
+/*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
+ * Unit tests for SbThreadPool
+ */
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "shared/utils/thread_pool.h"
+
+#define TEST_ASSERT(condition, message)                                        \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      fprintf(stderr, "TEST FAILED: %s\n", message);                           \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+typedef struct {
+  atomic_uint* hits; // Per-item execution counter (detects misses/duplicates)
+  atomic_uint processed;
+  uint32_t num_items;
+} FillContext;
+
+static void fill_task(void* arg, uint32_t start, uint32_t count) {
+  FillContext* ctx = (FillContext*)arg;
+  for (uint32_t i = start; i < start + count; i++) {
+    atomic_fetch_add_explicit(&ctx->hits[i], 1U, memory_order_relaxed);
+  }
+  atomic_fetch_add_explicit(&ctx->processed, count, memory_order_relaxed);
+}
+
+static void fill_context_init(FillContext* ctx, uint32_t num_items) {
+  ctx->num_items = num_items;
+  ctx->hits = (atomic_uint*)calloc(num_items, sizeof(atomic_uint));
+  TEST_ASSERT(ctx->hits != NULL, "Failed to allocate hits array");
+  for (uint32_t i = 0; i < num_items; i++) {
+    atomic_init(&ctx->hits[i], 0U);
+  }
+  atomic_init(&ctx->processed, 0U);
+}
+
+static void fill_context_verify_and_free(FillContext* ctx,
+                                         const char* case_name) {
+  TEST_ASSERT(atomic_load(&ctx->processed) == ctx->num_items, case_name);
+  for (uint32_t i = 0; i < ctx->num_items; i++) {
+    if (atomic_load(&ctx->hits[i]) != 1U) {
+      fprintf(stderr, "  item %u hit %u times (%s)\n", i,
+              atomic_load(&ctx->hits[i]), case_name);
+      TEST_ASSERT(atomic_load(&ctx->hits[i]) == 1U, case_name);
+    }
+  }
+  free(ctx->hits);
+}
+
+static void test_pool_null_fallback(void) {
+  printf("Testing NULL pool sequential fallback...\n");
+
+  FillContext ctx;
+  fill_context_init(&ctx, 16U);
+  sb_thread_pool_parallel_for(NULL, 16U, fill_task, &ctx);
+  fill_context_verify_and_free(&ctx, "NULL pool should run sequentially");
+
+  printf("✓ NULL pool sequential fallback tests passed\n");
+}
+
+static void test_pool_edge_cases(void) {
+  printf("Testing pool edge cases...\n");
+
+  TEST_ASSERT(sb_thread_pool_create(0U) == NULL,
+              "Zero workers should be rejected");
+  sb_thread_pool_free(NULL); // Must be a no-op
+
+  FillContext ctx;
+
+  fill_context_init(&ctx, 0U);
+  SbThreadPool* pool = sb_thread_pool_create(4U);
+  TEST_ASSERT(pool != NULL, "Pool creation failed");
+  sb_thread_pool_parallel_for(pool, 0U, fill_task, &ctx);
+  TEST_ASSERT(atomic_load(&ctx.processed) == 0U,
+              "Zero items should process nothing");
+  free(ctx.hits);
+
+  fill_context_init(&ctx, 1U);
+  sb_thread_pool_parallel_for(pool, 1U, fill_task, &ctx);
+  fill_context_verify_and_free(&ctx, "Single item should process once");
+
+  // Fewer items than participants
+  fill_context_init(&ctx, 2U);
+  sb_thread_pool_parallel_for(pool, 2U, fill_task, &ctx);
+  fill_context_verify_and_free(&ctx, "Two items on five threads");
+
+  sb_thread_pool_free(pool);
+
+  printf("✓ Pool edge case tests passed\n");
+}
+
+static void test_pool_parallel_correctness(void) {
+  printf("Testing pool parallel correctness...\n");
+
+  SbThreadPool* pool = sb_thread_pool_create(3U);
+  TEST_ASSERT(pool != NULL, "Pool creation failed");
+  TEST_ASSERT(sb_thread_pool_num_workers(pool) == 3U, "Worker count mismatch");
+
+  FillContext ctx;
+  fill_context_init(&ctx, 1000U);
+  sb_thread_pool_parallel_for(pool, 1000U, fill_task, &ctx);
+  fill_context_verify_and_free(&ctx, "Parallel fill should cover all items");
+
+  // Repeated dispatches reuse the same workers and work item storage
+  for (uint32_t round = 0; round < 200U; round++) {
+    fill_context_init(&ctx, 64U);
+    sb_thread_pool_parallel_for(pool, 64U, fill_task, &ctx);
+    fill_context_verify_and_free(&ctx, "Repeated dispatch should stay correct");
+  }
+
+  sb_thread_pool_free(pool);
+
+  printf("✓ Pool parallel correctness tests passed\n");
+}
+
+int main(void) {
+  test_pool_null_fallback();
+  test_pool_edge_cases();
+  test_pool_parallel_correctness();
+
+  printf("\n✅ All thread pool tests passed!\n");
+  return 0;
+}

--- a/tests/test_thread_pool.c
+++ b/tests/test_thread_pool.c
@@ -53,8 +53,12 @@ static void fill_task(void* arg, uint32_t start, uint32_t count) {
 
 static void fill_context_init(FillContext* ctx, uint32_t num_items) {
   ctx->num_items = num_items;
-  ctx->hits = (atomic_uint*)calloc(num_items, sizeof(atomic_uint));
-  TEST_ASSERT(ctx->hits != NULL, "Failed to allocate hits array");
+  // calloc(0) may legally return NULL; only assert for non-empty ranges.
+  ctx->hits = num_items > 0U
+                  ? (atomic_uint*)calloc(num_items, sizeof(atomic_uint))
+                  : NULL;
+  TEST_ASSERT(num_items == 0U || ctx->hits != NULL,
+              "Failed to allocate hits array");
   for (uint32_t i = 0; i < num_items; i++) {
     atomic_init(&ctx->hits[i], 0U);
   }


### PR DESCRIPTION
Fixes the Windows plugin load failure traced in lucianodato/noise-repellent#181 (via noise-repellent#188).

## Root cause

The NLM 2D filter parallelized with OpenMP. On MSVC, `/openmp:llvm` makes every binary dynamically import `libomp140.x86_64.dll` — a runtime that ships only inside Visual Studio, is explicitly non-redistributable, and is absent on end-user machines, so plugins failed to load in hosts like Ardour. On macOS the equivalent dependency was homebrew `libomp` (local builds only, but the same portability hazard). Beyond portability, OpenMP inside an audio callback lazily spawns its thread pool (allocation in the RT path), uses `schedule(dynamic)` (non-deterministic accumulation order), and hardcodes `num_threads(4)` per instance.

## This PR

- Add `SbThreadPool` (`src/shared/utils/thread_pool.h/.c`): fixed-size worker pool created at filter initialization. Per-worker private semaphores give exactly-once wakeups (Win32 / GCD / POSIX per platform); work items are published via semaphore synchronization; static contiguous partitioning keeps per-bin accumulation order identical to sequential execution; the calling thread participates in every dispatch; workers sleep between dispatches (no idle CPU) and run with FTZ/DAZ enabled.
- Drive the NLM block-smoothing loop through `sb_thread_pool_parallel_for`; remove all OpenMP usage, detection, and linking from the build.
- Thread count configurable per instance via `NlmFilterConfig::num_threads` (0 → `NLM_NUM_THREADS_DEFAULT` = 4); graceful fallback to single-threaded if pool creation fails.
- Tests: new `test_thread_pool.c` (coverage/edge cases/repeated dispatch); `test_nlm_filter` OMP env test replaced by threading-config tests.
- Docs: README dependency + performance notes updated; CHANGELOG entry.

## Verification

- 31/31 tests pass (incl. `test_audio_file_regression` — output unchanged vs reference files).
- Stress: 1–8 workers × 12 sizes × 300 rounds, every item processed exactly once; 40k+ dispatch runs clean; deterministic output verified against sequential execution.
- Plugin build (noise-repellent): `otool` confirms no `libomp`/`libgomp` linkage; pool symbols embedded.

**Note for reviewer:** `main` will be rewound to `b46a396` before merge so this lands as a single clean commit (the two commits currently on `main` are pre-squash duplicates of this content).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable NLM processing thread counts, defaulting to four and supporting up to 16 threads.
  * Replaced OpenMP-based processing with a built-in, cross-platform worker pool.
  * Added deterministic workload distribution and automatic sequential fallback if threading is unavailable.

* **Documentation**
  * Updated build requirements, performance guidance, and the unreleased changelog.

* **Tests**
  * Added comprehensive worker-pool coverage and updated NLM threading tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->