### PR TITLE
Improve C API ergonomics: RT contracts, zero-dep embed example, README quickstart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,16 @@ endif()
 # ==============================================================================
 # 7. Examples & Tests
 # ==============================================================================
+if(ENABLE_EXAMPLES)
+    # Zero-dependency embed example: no libsndfile required
+    add_executable(simple_embed "${CMAKE_CURRENT_SOURCE_DIR}/examples/simple_embed.c")
+    target_include_directories(simple_embed PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    target_link_libraries(simple_embed PRIVATE libspecbleach)
+    if(MATH_LIB)
+        target_link_libraries(simple_embed PRIVATE ${MATH_LIB})
+    endif()
+endif()
+
 if(ENABLE_EXAMPLES AND TARGET PkgConfig::SNDFILE)
     add_executable(denoiser_demo "${CMAKE_CURRENT_SOURCE_DIR}/examples/denoiser_demo.c")
     target_include_directories(denoiser_demo PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ C library for audio noise reduction and other spectral effects.
 - [Build](#build)
 - [Installation](#installation)
 - [Build Options](#build-options)
+- [Quick Integration](#quick-integration)
 - [Usage Examples](#usage-examples)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -106,6 +107,43 @@ cmake -B build \
 
 cmake --build build --config Release --parallel
 ```
+
+## Quick Integration
+
+```c
+#include <specbleach_denoiser.h>
+
+// 1. CREATE — one instance per channel; frame_size_ms = STFT window (20-100)
+specbleach_denoiser* denoiser =
+    specbleach_denoiser_initialize(sample_rate, 46.0f);
+
+// Report latency to your host for delay compensation (stable after init)
+uint32_t latency = specbleach_denoiser_get_latency(denoiser);
+
+// 2. CONFIGURE — library copies everything
+SpecbleachDenoiserParameters p = {0};
+p.learn_noise = SPECBLEACH_LEARN_ALL;
+p.reduction_gain = 0.1f;                          // -20 dB
+specbleach_denoiser_load_parameters(denoiser, &p, sizeof(p));
+
+// 3. LEARN — feed blocks containing only noise (RT-safe call)
+specbleach_denoiser_process(denoiser, nframes, in, out);
+
+// 4. FINALIZE — profiles are only usable after learning turns OFF
+p.learn_noise = SPECBLEACH_LEARN_OFF;
+specbleach_denoiser_load_parameters(denoiser, &p, sizeof(p));
+
+// 5. REDUCE — same call shape forever after; any block size (RT-safe)
+specbleach_denoiser_process(denoiser, nframes, in, out);
+
+// 6. CLEANUP (setup thread only, not RT-safe)
+specbleach_denoiser_free(denoiser);
+```
+
+Buffers are plain planar float arrays of `nframes` length; output may alias
+input. `_process` is real-time safe (no allocations, locks, or I/O);
+parameter loads and create/destroy are not. A complete zero-dependency
+example lives in [`examples/simple_embed.c`](examples/simple_embed.c).
 
 ## Usage Examples
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,13 +7,15 @@ then steal its structure — they are written to be copied.
 
 | Your situation | Read | Uses |
 | :--- | :--- | :--- |
+| Embedding the library anywhere, no file I/O | [`simple_embed.c`](simple_embed.c) | Core API, zero dependencies |
 | Mono processing, offline or simple pipeline | [`denoiser_demo.c`](denoiser_demo.c) | Core API only (`specbleach_denoiser.h`) |
 | Stereo/surround, smoothing-mode switching, "what the plugin does" | [`stereo_denoiser_demo.c`](stereo_denoiser_demo.c) | Extras layer (`specbleach_stereo.h`) |
 | Real-time application with GUI-driven learn/switch | `stereo_denoiser_demo.c` **plus** the [Noise Repellent plugin source](https://github.com/lucianodato/noise-repellent/blob/master/Source/PluginProcessor.cpp) | Extras + threading patterns |
 
-Both demos process audio files via libsndfile so they are runnable and
+Both file demos process audio via libsndfile so they are runnable and
 verifiable; everything except file I/O maps 1:1 to real-time callback code,
 and the demos call out exactly where the real-time differences are.
+`simple_embed.c` has no external dependencies at all.
 
 ## The 60-second version
 

--- a/examples/simple_embed.c
+++ b/examples/simple_embed.c
@@ -1,0 +1,134 @@
+/*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/**
+ * @file simple_embed.c
+ * @brief Zero-dependency embedding example: denoises a synthetic signal.
+ *
+ * Demonstrates the complete processing lifecycle with no external libraries
+ * (no libsndfile), so it builds and runs anywhere the library builds:
+ * generate noisy audio -> learn a noise profile -> denoise -> verify the
+ * noise actually dropped -> clean up. Every call here maps 1:1 to a
+ * real-time audio callback integration.
+ *
+ * Build: cmake -B build -DENABLE_EXAMPLES=ON && cmake --build build
+ * Run:   ./build/simple_embed
+ */
+
+#include <math.h>
+#include <specbleach_denoiser.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define SAMPLE_RATE 48000U
+#define FRAME_SIZE_MS 46.0f
+#define BLOCK_SIZE 512U
+#define LEARN_BLOCKS 8U
+#define TOTAL_BLOCKS 64U
+
+static float make_noisy_sample(uint32_t sample_rate, uint32_t index) {
+  // 220 Hz tone plus white noise floor
+  float tone = 0.25f * sinf(2.0f * (float)M_PI * 220.0f * (float)index /
+                            (float)sample_rate);
+  float noise =
+      ((float)((index * 1103515245U + 12345U) >> 16) / (float)(1U << 15)) -
+      1.0f;
+  return tone + 0.05f * noise;
+}
+
+int main(void) {
+  float input[BLOCK_SIZE];
+  float output[BLOCK_SIZE];
+
+  // 1. CREATE
+  specbleach_denoiser* denoiser =
+      specbleach_denoiser_initialize(SAMPLE_RATE, FRAME_SIZE_MS);
+  if (!denoiser) {
+    fprintf(stderr, "Error: failed to initialize denoiser\n");
+    return 1;
+  }
+
+  // Report algorithmic latency to your host for delay compensation
+  printf("Latency: %u samples\n", specbleach_denoiser_get_latency(denoiser));
+
+  // 2. CONFIGURE (learning on)
+  SpecbleachDenoiserParameters parameters = {0};
+  parameters.learn_noise = SPECBLEACH_LEARN_ALL;
+  parameters.reduction_gain = 0.1f; // -20 dB
+  if (!specbleach_denoiser_load_parameters(denoiser, &parameters,
+                                           sizeof(parameters))) {
+    fprintf(stderr, "Error: failed to load parameters\n");
+    specbleach_denoiser_free(denoiser);
+    return 1;
+  }
+
+  // 3. LEARN — feed blocks containing ONLY noise
+  for (uint32_t i = 0; i < LEARN_BLOCKS; i++) {
+    for (uint32_t n = 0; n < BLOCK_SIZE; n++) {
+      input[n] = make_noisy_sample(SAMPLE_RATE, i * BLOCK_SIZE + n);
+    }
+    if (!specbleach_denoiser_process(denoiser, BLOCK_SIZE, input, output)) {
+      fprintf(stderr, "Error: learn stage failed\n");
+      specbleach_denoiser_free(denoiser);
+      return 1;
+    }
+  }
+
+  // 4. FINALIZE — profiles are only usable after learning turns OFF
+  parameters.learn_noise = SPECBLEACH_LEARN_OFF;
+  if (!specbleach_denoiser_load_parameters(denoiser, &parameters,
+                                           sizeof(parameters))) {
+    fprintf(stderr, "Error: failed to finalize parameters\n");
+    specbleach_denoiser_free(denoiser);
+    return 1;
+  }
+
+  // 5. REDUCE — same call shape for the rest of the stream
+  float in_rms = 0.0f;
+  float out_rms = 0.0f;
+  for (uint32_t i = LEARN_BLOCKS; i < TOTAL_BLOCKS; i++) {
+    for (uint32_t n = 0; n < BLOCK_SIZE; n++) {
+      input[n] = make_noisy_sample(SAMPLE_RATE, i * BLOCK_SIZE + n);
+    }
+    if (!specbleach_denoiser_process(denoiser, BLOCK_SIZE, input, output)) {
+      fprintf(stderr, "Error: reduction stage failed\n");
+      specbleach_denoiser_free(denoiser);
+      return 1;
+    }
+    for (uint32_t n = 0; n < BLOCK_SIZE; n++) {
+      in_rms += input[n] * input[n];
+      out_rms += output[n] * output[n];
+    }
+  }
+  in_rms = sqrtf(in_rms / (float)((TOTAL_BLOCKS - LEARN_BLOCKS) * BLOCK_SIZE));
+  out_rms =
+      sqrtf(out_rms / (float)((TOTAL_BLOCKS - LEARN_BLOCKS) * BLOCK_SIZE));
+  printf("Input RMS: %f  Output RMS: %f\n", (double)in_rms, (double)out_rms);
+
+  // 6. CLEANUP
+  specbleach_denoiser_free(denoiser);
+
+  if (out_rms >= in_rms) {
+    fprintf(stderr, "FAIL: output level did not decrease (no reduction)\n");
+    return 1;
+  }
+  printf("PASS: denoiser reduced signal level\n");
+  return 0;
+}

--- a/extras/include/specbleach_stereo.h
+++ b/extras/include/specbleach_stereo.h
@@ -38,6 +38,13 @@ extern "C" {
  * instance per channel, fans parameter loads out to every channel, and
  * provides the profile bookkeeping multi-channel applications otherwise
  * reimplement. It contains no DSP of its own.
+ *
+ * Real-time contract: same classification as specbleach_denoiser.h.
+ * "RT-safe" functions (process, get_latency, read-only queries) carry no
+ * allocations, locks, or I/O and are safe for the audio callback thread;
+ * all other functions (create, free, parameter/profile loads, sync/reset)
+ * are setup-only and must be called from a control thread. Calls on the
+ * same instance must never run concurrently with process().
  */
 
 /**
@@ -53,12 +60,16 @@ typedef struct specbleach_stereo
  * symmetric code paths).
  * @return New instance or NULL on failure. Free with
  * specbleach_stereo_free().
+ *
+ * Thread safety: setup-only (allocates one engine per channel).
  */
 SPECBLEACH_API specbleach_stereo* specbleach_stereo_initialize(
     uint32_t sample_rate, float frame_size, uint32_t channels);
 
 /**
  * Frees the instance and every underlying engine. NULL is a no-op.
+ *
+ * Thread safety: setup-only (deallocates).
  */
 SPECBLEACH_API void specbleach_stereo_free(specbleach_stereo* instance);
 
@@ -72,15 +83,21 @@ SPECBLEACH_API void specbleach_stereo_free(specbleach_stereo* instance);
  * reduction_curve_bias (each channel owns its copy; first enabled load may
  * allocate). The smoothing_mode field can be changed at runtime; the
  * library performs the internal seamless crossfade.
+ *
+ * Thread safety: setup-only (copies parameters to every channel; first
+ * curve-enabled load may allocate).
  */
 SPECBLEACH_API bool specbleach_stereo_load_parameters(
     specbleach_stereo* instance, const SpecbleachDenoiserParameters* parameters,
     uint32_t parameters_size);
 
 /**
- * Processes all channels. Buffers are deinterleaved: input[i] / output[i]
- * address channel i, each holding number_of_samples frames. Real-time safe;
- * may allocate-free on first curve-enabled load as documented above.
+ * Processes all channels. Buffers are deinterleaved (planar): input[i] /
+ * output[i] address channel i, each holding number_of_samples frames. Any
+ * block size is accepted.
+ *
+ * Thread safety: RT-safe (no allocations, locks, or I/O). Safe for the
+ * real-time audio callback thread.
  */
 SPECBLEACH_API bool specbleach_stereo_process(specbleach_stereo* instance,
                                               uint32_t number_of_samples,
@@ -89,13 +106,18 @@ SPECBLEACH_API bool specbleach_stereo_process(specbleach_stereo* instance,
 
 /**
  * Returns the channel count passed at initialization.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API uint32_t
 specbleach_stereo_get_channel_count(const specbleach_stereo* instance);
 
 /**
  * Returns the algorithmic latency in samples (identical for every channel).
- * Constant across smoothing mode changes.
+ * Constant across smoothing mode changes; query once at prepare time for
+ * host delay compensation.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API uint32_t
 specbleach_stereo_get_latency(const specbleach_stereo* instance);
@@ -116,6 +138,8 @@ SPECBLEACH_API bool specbleach_stereo_sync_profiles(
 
 /**
  * Resets stored noise profiles on every channel.
+ *
+ * Thread safety: setup-only.
  */
 SPECBLEACH_API bool specbleach_stereo_reset_profiles(
     specbleach_stereo* instance);
@@ -124,6 +148,9 @@ SPECBLEACH_API bool specbleach_stereo_reset_profiles(
  * Per-channel profile accessors forwarding to the underlying engine.
  * Pointers stay valid until the instance is freed. mode must be within
  * [SPECBLEACH_PROFILE_MODE_FIRST, SPECBLEACH_PROFILE_MODE_LAST].
+ *
+ * Thread safety: getters are RT-safe (read-only); the load function is
+ * setup-only (copies profile data).
  */
 SPECBLEACH_API float* specbleach_stereo_get_noise_profile_for_channel(
     specbleach_stereo* instance, uint32_t channel, int mode);
@@ -137,6 +164,8 @@ SPECBLEACH_API uint32_t specbleach_stereo_get_profile_block_count_for_channel(
 
 /**
  * Returns the size of the noise profile spectrum in bins.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API uint32_t
 specbleach_stereo_get_noise_profile_size(const specbleach_stereo* instance);
@@ -144,13 +173,17 @@ specbleach_stereo_get_noise_profile_size(const specbleach_stereo* instance);
 /**
  * Returns the maximum transient intensity [0.0, 1.0] across channels from
  * the last processed block.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API float specbleach_stereo_get_transient_intensity(
     specbleach_stereo* instance);
 
 /**
  * Per-channel visualization/query forwarders. See the engine headers for
- * semantics and threading notes (tonal peak queries are offline-only).
+ * semantics and threading notes (tonal peak queries are offline-only,
+ * setup-only; the mask/active-profile pointers are RT-safe read-only
+ * queries into live internal state).
  */
 SPECBLEACH_API const float* specbleach_stereo_get_tonal_mask_for_channel(
     specbleach_stereo* instance, uint32_t channel);

--- a/include/specbleach_denoiser.h
+++ b/include/specbleach_denoiser.h
@@ -85,8 +85,10 @@ typedef struct specbleach_denoiser specbleach_denoiser;
 /**
  * Parameters for the spectral denoiser.
  *
- * Thread safety contract for the whole header: unless explicitly stated
- * otherwise, functions taking a handle may be called from any thread, but
+ * Real-time contract for the whole header: every function is classified as
+ * either "RT-safe" (no allocations, no locks, no I/O — callable from a
+ * real-time audio callback thread) or "setup-only" (may allocate, block, or
+ * copy — call it from a control/setup thread only). Unless stated otherwise,
  * calls on the SAME instance must never run concurrently with each other or
  * with specbleach_denoiser_process().
  */
@@ -218,6 +220,8 @@ typedef struct SpecbleachDenoiserParameters {
  * Sample rate can be anything from 4000 Hz to 192 kHz. Recommended frame
  * size range is between 20 ms and 100 ms.
  *
+ * Thread safety: setup-only (allocates). Never call from an audio thread.
+ *
  * @return A new instance or NULL on allocation failure. Free it with
  * specbleach_denoiser_free().
  */
@@ -227,6 +231,8 @@ SPECBLEACH_API specbleach_denoiser* specbleach_denoiser_initialize(
 /**
  * Frees an instance created by specbleach_denoiser_initialize().
  * Passing NULL is a no-op. The handle is invalid after this call.
+ *
+ * Thread safety: setup-only (deallocates). Never call from an audio thread.
  */
 SPECBLEACH_API void specbleach_denoiser_free(specbleach_denoiser* instance);
 
@@ -241,7 +247,7 @@ SPECBLEACH_API void specbleach_denoiser_free(specbleach_denoiser* instance);
  * between separately compiled binaries; any other value fails cleanly
  * instead of reading out-of-bounds memory.
  *
- * Not guaranteed to be allocation-free on the FIRST call after enabling
+ * Thread safety: setup-only. May allocate on the FIRST call after enabling
  * reduction_curve_enabled (the internal copy buffer is allocated then);
  * subsequent calls reuse that buffer. Load parameters once during setup if
  * strict audio-thread allocation freedom is required.
@@ -256,7 +262,12 @@ SPECBLEACH_API bool specbleach_denoiser_load_parameters(
 /**
  * Processes a buffer of samples in place-capable buffers.
  *
- * Real-time safe: contains no allocations, locks, or I/O.
+ * Thread safety: RT-safe (no allocations, locks, or I/O). Safe for the
+ * real-time audio callback thread.
+ *
+ * Buffer contract: input/output are plain float arrays of
+ * number_of_samples length (mono, non-interleaved). Any block size is
+ * accepted - internal buffering handles alignment. Output may alias input.
  *
  * @return true on success, false on NULL arguments or an empty block.
  */
@@ -268,18 +279,27 @@ SPECBLEACH_API bool specbleach_denoiser_process(specbleach_denoiser* instance,
 /**
  * Returns the algorithmic latency in samples introduced by the instance.
  * Hosts should report this value for delay compensation.
+ *
+ * Thread safety: RT-safe (read-only query). The value is stable for the
+ * lifetime of the instance; query it once at prepare time. Smoothing mode
+ * switches never change it.
  */
 SPECBLEACH_API uint32_t
 specbleach_denoiser_get_latency(specbleach_denoiser* instance);
 
 /**
  * Returns the size of the noise profile spectrum in bins.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API uint32_t
 specbleach_denoiser_get_noise_profile_size(specbleach_denoiser* instance);
 
 /**
  * Loads a custom noise profile for a specific mode.
+ *
+ * Thread safety: setup-only (copies profile data). Never call from an
+ * audio thread.
  *
  * @param mode One of [SPECBLEACH_PROFILE_MODE_FIRST,
  * SPECBLEACH_PROFILE_MODE_LAST].
@@ -291,6 +311,8 @@ SPECBLEACH_API bool specbleach_denoiser_load_noise_profile_for_mode(
 
 /**
  * Resets the internal noise profile of the instance.
+ *
+ * Thread safety: setup-only. Never call from an audio thread.
  */
 SPECBLEACH_API bool specbleach_denoiser_reset_noise_profile(
     specbleach_denoiser* instance);
@@ -298,6 +320,8 @@ SPECBLEACH_API bool specbleach_denoiser_reset_noise_profile(
 /**
  * Returns the number of blocks used for the noise profile calculation for a
  * specific mode.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API uint32_t
 specbleach_denoiser_get_noise_profile_block_count_for_mode(
@@ -309,12 +333,17 @@ specbleach_denoiser_get_noise_profile_block_count_for_mode(
  * only for a NULL instance or an out-of-range mode. Use
  * specbleach_denoiser_noise_profile_available_for_mode() to check whether
  * learning has completed and the profile has been populated.
+ *
+ * Thread safety: RT-safe (read-only query). The returned pointer points to
+ * live internal state and must not be written to or retained past free().
  */
 SPECBLEACH_API float* specbleach_denoiser_get_noise_profile_for_mode(
     specbleach_denoiser* instance, int mode);
 
 /**
  * Returns whether a noise profile has been calculated for a specific mode.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API bool specbleach_denoiser_noise_profile_available_for_mode(
     specbleach_denoiser* instance, int mode);
@@ -324,6 +353,9 @@ SPECBLEACH_API bool specbleach_denoiser_noise_profile_available_for_mode(
  * processing. Array size matches
  * specbleach_denoiser_get_noise_profile_size(instance). Values range from
  * 0.0 (broadband) to 1.0 (pure tone).
+ *
+ * Thread safety: RT-safe (read-only query). Pointer points to live internal
+ * state; valid until the instance is freed.
  */
 SPECBLEACH_API const float* specbleach_denoiser_get_tonal_mask(
     specbleach_denoiser* instance);
@@ -335,6 +367,8 @@ SPECBLEACH_API const float* specbleach_denoiser_get_tonal_mask(
  * Offline/query-only API; must NOT be called from the real-time audio
  * thread.
  *
+ * Thread safety: setup-only.
+ *
  * @return Number of peak frequencies written.
  */
 SPECBLEACH_API uint32_t specbleach_denoiser_get_tonal_peaks(
@@ -342,12 +376,17 @@ SPECBLEACH_API uint32_t specbleach_denoiser_get_tonal_peaks(
 
 /**
  * Returns a pointer to the active morphed noise profile array.
+ *
+ * Thread safety: RT-safe (read-only query). Pointer points to live internal
+ * state; valid until the instance is freed.
  */
 SPECBLEACH_API const float* specbleach_denoiser_get_active_noise_profile(
     specbleach_denoiser* instance);
 
 /**
  * Returns true if a transient was detected in the last processed frame.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API bool specbleach_denoiser_is_transient_detected(
     specbleach_denoiser* instance);
@@ -355,6 +394,8 @@ SPECBLEACH_API bool specbleach_denoiser_is_transient_detected(
 /**
  * Returns the detected transient intensity [0.0, 1.0] from the last
  * processed frame.
+ *
+ * Thread safety: RT-safe (read-only query).
  */
 SPECBLEACH_API float specbleach_denoiser_get_transient_intensity(
     specbleach_denoiser* instance);


### PR DESCRIPTION
Closes #148

## Changes
- **`examples/simple_embed.c`**: zero-dependency integration example demonstrating the complete processing lifecycle (create → configure → learn → finalize → reduce → cleanup) with synthetic buffers. Builds as `simple_embed` target with no libsndfile requirement. Self-verifying: fails if reduction did not decrease output level.
- **Front-page README**: new "Quick Integration" section with the full C snippet plus buffer/latency/RT notes, linking to `simple_embed.c`.
- **RT-safety contract in headers**: every public function in `specbleach_denoiser.h` and `specbleach_stereo.h` now carries an explicit thread-safety classification — `RT-safe` (no allocations, locks, or I/O; audio callback thread) vs `setup-only` (may allocate/block/copy; control thread).
- **Latency & buffer contract**: `_get_latency` documented as stable for the instance lifetime (query at prepare time); `_process` documents planar mono layout, arbitrary block sizes, and in-place aliasing.

## Verification
- `simple_embed` builds and runs: `PASS: denoiser reduced signal level` (4416-sample latency reported)
- Full test suite: 33/33 passed