### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.2] - Unreleased
+## [0.4.0] - 2026-09-07
+
+### Changed (Breaking)
+- **Type-safe public API**: Reworked public C API around library best practices with type-safe handles and an optional orchestration extras layer. Fallible calls fail fast with `bool`; see README for the zero-dependency embed example.
+- **Linear parameter scale**: API parameters now use linear scale and normalized ranges instead of `remap_percentage_log_like_unity`.
+- **Init flags**: `specbleach_denoiser_initialize()` / `specbleach_stereo_initialize()` take a new `flags` parameter (`SPECBLEACH_INIT_LOW_LATENCY`, `flags = 0` preserves legacy behavior).
 
 ### Removed
 - **Dead stereo API surface**: Removed nine `specbleach_stereo_*` functions with zero callers (`get_sample_rate`, `get_frame_size`, `get_fft_size`, `get_hop_size`, `reset_dsp_state`, `is_transient_detected`, `is_transient_detected_for_channel`, `get_tonal_mask_for_channel`, `get_last_error`) along with the now write-only `last_error` bookkeeping, and the unused `SPECBLEACH_VERSION_NUMBER` macro. The mono `specbleach_denoiser_*` equivalents remain the supported path.
@@ -13,16 +18,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Low-latency mode**: New `SPECBLEACH_INIT_LOW_LATENCY` init flag (new `flags` parameter on `specbleach_denoiser_initialize()` / `specbleach_stereo_initialize()`, defaulted in the C++ wrappers) selecting a causal 1D-only path with zero look-ahead. NLM/DFTT smoothing requests are clamped to temporal internally; masking veto and transient protection stay active. Combined with a 512-sample frame, total latency is ~10.7 ms at 48 kHz / ~11.6 ms at 44.1 kHz for live hosts. The frame runs at 8x overlap (64-sample hop) for agile gain updates with standard FFT padding; reported latency stays one frame. `flags = 0` preserves legacy behavior.
+- **Post-NLM DFTT refinement**: New Discrete Fourier Transform Thresholding stage (Lukin & Todd AES123 §4.2) after NLM 2D smoothing, with past-heavy NLM geometry.
+- **Adaptive Wiener knee**: Per-bin decay-evidence knee plus release shaper for smoother suppression tails.
+- **Frame-rate-independent time constants**: DSP attack/release constants now normalize to wall-clock time regardless of STFT hop/frame rate.
+- **HPSS transient protection**: Zero-latency sliding Harmonic-Percussive Source Separation filter with transient preservation.
+- **Tonal detection**: CV-based tonal detection, statistical variance profile matching, and tonal noise profile scale.
+- **Threshold offset & custom reduction curve**: User-controllable threshold offset and custom reduction curve mapping.
+- **Quality metrics suite**: Real-world quality metrics over committed fixture cases (`test_integration_realworld_quality`).
 - **Internal Thread Pool**: Added `SbThreadPool` (`src/shared/utils/thread_pool.h`), a fixed-size worker pool with semaphore-based dispatch and static contiguous partitioning, powering multi-threaded NLM 2D smoothing without any external threading runtime. Thread count is configurable per instance via `NlmFilterConfig::num_threads` (default `NLM_NUM_THREADS_DEFAULT`).
 
 ### Improved & Refactored
 - **PFFFT Migration**: Replaced FFTW3 backend with vendored PFFFT (`thirdparty/pffft/`). Eliminated external FFTW runtime/dynamic dependency, GPL linking restrictions, network FetchContent dependencies, and packaging overhead.
-- **OpenMP Removal**: Replaced OpenMP parallelization in the NLM 2D filter with the internal worker pool. Binaries no longer depend on `libomp`/`libgomp`/`libomp140` runtimes, dispatches are deterministic (static partitioning instead of dynamic scheduling), and no threads or locks are created in the audio path.
+- **OpenMP Removal**: Replaced OpenMP parallelization in the NLM 2D filter with the internal worker pool. Binaries no longer depend on `libomp`/`libgomp`/`libomp140` runtimes and dispatches are deterministic (static partitioning instead of dynamic scheduling). No threads are created in the audio path (pool is created at init); note that 2D mode still blocks the calling thread on worker completion, so the hard-real-time path is the causal 1D / low-latency mode. Restructured RT contracts are documented in the README.
+- **Denoiser consolidation**: Merged temporal and 2D NLM denoisers into a single processor; synced aggressiveness tracking and added silence bypass optimization plus reduced CPU usage during learn and idle.
 - **Adaptive Profile Persistence**: Updated standalone adaptive noise estimation to persist learned noise profiles to the noise profile manager so estimated spectral curves remain available when switching to manual mode.
 - **Manual Baseline Re-seeding**: Fixed standalone adaptive mode state tracking to reset hybrid initialization state when no manual profile exists, ensuring manual noise profiles captured while adaptive mode is active immediately morph and seed the baseline floor.
 
 ### Fixed
-
+- **Audio artifacts**: Fixed various output artifacts during the 0.4.0 cycle (NLM temporal alignment, HPSS temporal magnitude caching).
 
 ## [0.3.1] - 2026-08-07
 
@@ -75,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made demo applications accept command-line arguments for all processing parameters
 - Improved STFT processor input latency calculation
 - Enhanced memory initialization and error handling across all modules
-- Library now generates versioned shared objects (libspecbleach.so.0.2.0, libspecbleach.so.0)
+- Library now generates versioned shared objects (libspecbleach.so.0.4.0, libspecbleach.so.0)
 
 ### Fixed
 - STFT input latency bug causing incorrect delay calculations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Post-NLM DFTT refinement**: New Discrete Fourier Transform Thresholding stage (Lukin & Todd AES123 §4.2) after NLM 2D smoothing, with past-heavy NLM geometry.
 - **Adaptive Wiener knee**: Per-bin decay-evidence knee plus release shaper for smoother suppression tails.
 - **Frame-rate-independent time constants**: DSP attack/release constants now normalize to wall-clock time regardless of STFT hop/frame rate.
-- **HPSS transient protection**: Zero-latency sliding Harmonic-Percussive Source Separation filter with transient preservation.
+- **Transient protection**: Onset-based transient veto (`transient_protection_enable`, formerly misnamed `hpss_enable`) that freezes gain updates on transient bins. It does not use HPSS separation; the standalone sliding-HPSS module remains available but unwired.
 - **Tonal detection**: CV-based tonal detection, statistical variance profile matching, and tonal noise profile scale.
 - **Threshold offset & custom reduction curve**: User-controllable threshold offset and custom reduction curve mapping.
 - **Quality metrics suite**: Real-world quality metrics over committed fixture cases (`test_integration_realworld_quality`).

--- a/examples/denoiser_demo.c
+++ b/examples/denoiser_demo.c
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
       .whitening_factor = 0.5f,
       .masking_depth = 0.5f,
       .tonal_reduction_gain = 1.0f,
-      .hpss_enable = true};
+      .transient_protection_enable = true};
 
   static struct option long_options[] = {
       {"reduction", required_argument, 0, 'r'},

--- a/examples/stereo_denoiser_demo.c
+++ b/examples/stereo_denoiser_demo.c
@@ -256,7 +256,7 @@ int main(int argc, char** argv) {
     params.learn_noise = SPECBLEACH_LEARN_ALL;
     params.reduction_gain = powf(10.0f, -options.reduction_db / 20.0f);
     params.smoothing_mode = SPECBLEACH_SMOOTHING_TEMPORAL;
-    params.hpss_enable = true;
+    params.transient_protection_enable = true;
 
     if (!specbleach_stereo_load_parameters(group, &params, sizeof(params))) {
       break;

--- a/include/specbleach_denoiser.h
+++ b/include/specbleach_denoiser.h
@@ -204,9 +204,10 @@ typedef struct SpecbleachDenoiserParameters {
   float tonal_reduction_gain;
 
   /**
-   * Enables HPSS transient protection.
+   * Enables transient protection: onset-based transient veto that freezes
+   * gain updates on transient bins (not HPSS separation).
    */
-  bool hpss_enable;
+  bool transient_protection_enable;
 
   /**
    * Noise Profile Linear Scale — multiplier for the noise power spectrum.

--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -730,7 +730,7 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   // 2.1 Transient Detection via Transient Detector across Critical Bands
   // Transient detection runs on a clean signal estimate with scaled-up noise
   // subtraction to avoid false triggering from residual musical noise.
-  bool transient_enabled = (self->parameters.hpss_enable != 0);
+  bool transient_enabled = (self->parameters.transient_protection_enable != 0);
   if (transient_enabled && self->critical_bands && self->transient_detector) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
       // Scale noise up using TRANSIENT_CLEAN_NOISE_SCALE to eliminate spurious

--- a/src/processors/denoiser/spectral_denoiser.h
+++ b/src/processors/denoiser/spectral_denoiser.h
@@ -46,7 +46,7 @@ typedef struct DenoiserParameters {
   float suppression_strength; /**< Suppression aggressiveness (0.0 to 1.0) */
   float aggressiveness;       /**< -1.0 (Median/Min) to 1.0 (Max), 0.0 (Mean) */
   float tonal_reduction;      /**< 0.0 to 1.0 */
-  int hpss_enable;            /**< 0=disabled, 1=enabled */
+  int transient_protection_enable;   /**< 0=disabled, 1=enabled */
   float noise_profile_offset_linear; /**< Linear scalar for noise profile */
   float tonal_noise_profile_offset_linear; /**< Linear scalar at tonal bins */
   const float* reduction_curve_bias;       /**< Per-bin dB bias, NULL = off */

--- a/src/processors/specbleach_denoiser.c
+++ b/src/processors/specbleach_denoiser.c
@@ -69,7 +69,8 @@ static DenoiserParameters sanitize_denoiser_parameters(
       .aggressiveness = fmaxf(-1.0f, fminf(1.0f, parameters->aggressiveness)),
       .tonal_reduction =
           fmaxf(0.0f, fminf(1.0f, parameters->tonal_reduction_gain)),
-      .hpss_enable = parameters->hpss_enable ? 1 : 0,
+      .transient_protection_enable =
+          parameters->transient_protection_enable ? 1 : 0,
       .noise_profile_offset_linear =
           fmaxf(0.01f, fminf(100.0f, parameters->noise_profile_scale > 0.0f
                                          ? parameters->noise_profile_scale
@@ -118,7 +119,7 @@ SpecbleachDenoiserParameters specbleach_denoiser_get_default_parameters(void) {
   p.suppression_strength = 1.0f;
   p.aggressiveness = 0.0f;
   p.tonal_reduction_gain = 0.1f;
-  p.hpss_enable = false;
+  p.transient_protection_enable = false;
   p.noise_profile_scale = 1.0f;
   p.reduction_curve_bias = NULL;
   p.reduction_curve_enabled = false;

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* --------------------------------------------------------------------- */
 /* Sections below follow the runtime signal pipeline: STFT front-end ->   */
-/* noise estimation -> tonal/transient analysis -> NLM/HPSS processing -> */
+/* noise estimation -> tonal/transient analysis -> NLM smoothing -> */
 /* gain computation -> masking -> gain smoothing -> core plumbing.        */
 /* --------------------------------------------------------------------- */
 
@@ -165,7 +165,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
   4.0F // Noise over-subtraction factor for clean transient estimation
 
 /* --------------------------------------------------------------------- */
-/* 4. NLM 2D smoothing (Lukin Algorithm B) and HPSS transient protection. */
+/* 4. NLM 2D smoothing (Lukin Algorithm B) and transient protection. */
 /* --------------------------------------------------------------------- */
 
 // NLM (Lukin Algorithm B) Parameters

--- a/tests/test_adaptive_noise_estimator.c
+++ b/tests/test_adaptive_noise_estimator.c
@@ -1,3 +1,23 @@
+/*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/tests/test_audio_file_regression.c
+++ b/tests/test_audio_file_regression.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Audio file regression tests - compare library output against reference files
  */
 

--- a/tests/test_audio_file_regression.c
+++ b/tests/test_audio_file_regression.c
@@ -22,7 +22,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  * Audio file regression tests - compare library output against reference files
  */
 
-#include "shared/denoiser_logic/processing/hpss_filter.h"
 #include <math.h>
 #include <sndfile.h>
 #include <specbleach_denoiser.h>
@@ -53,7 +52,7 @@ static const SpecbleachDenoiserParameters canonical_denoiser_params = {
     .smoothing_factor = 0.0f,
     .whitening_factor = 0.5f,
     .masking_depth = 0.5f,
-    .hpss_enable = true};
+    .transient_protection_enable = true};
 
 static const SpecbleachDenoiserParameters canonical_adenoiser_params = {
     .residual_listen = false,
@@ -61,7 +60,7 @@ static const SpecbleachDenoiserParameters canonical_adenoiser_params = {
     .smoothing_factor = 0.0f,
     .whitening_factor = 0.5f,
     .masking_depth = 0.5f,
-    .hpss_enable = true,
+    .transient_protection_enable = true,
 
     .adaptive_noise = true,
     .noise_estimation_method = SPECBLEACH_NOISE_ESTIMATION_SPP_MMSE};

--- a/tests/test_audio_files.c
+++ b/tests/test_audio_files.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Audio file validation tests - ensure test data is accessible
  */
 

--- a/tests/test_audio_regression.c
+++ b/tests/test_audio_regression.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Audio regression tests - compare processed audio against reference files
  */
 

--- a/tests/test_brandt_noise_estimator.c
+++ b/tests/test_brandt_noise_estimator.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Brandt Noise Estimator
  */
 

--- a/tests/test_fft.c
+++ b/tests/test_fft.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for FFT Transform
  */
 

--- a/tests/test_gain_calculator.c
+++ b/tests/test_gain_calculator.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Gain Calculator
  */
 

--- a/tests/test_integration.c
+++ b/tests/test_integration.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Integration tests for the full denoising pipeline
  */
 

--- a/tests/test_integration_realworld_quality.c
+++ b/tests/test_integration_realworld_quality.c
@@ -330,7 +330,7 @@ static SpecbleachDenoiserParameters make_parameters(float smoothing,
       .tonal_reduction_gain = reduction_gain,
       .dftt_strength =
           mode == 2U ? 1.0F + reduction_db / DFTT_STRENGTH_DOUBLING_DB : 1.0F,
-      .hpss_enable = false};
+      .transient_protection_enable = false};
 }
 
 // Measures the true stream delay empirically: noise burst on a scratch

--- a/tests/test_martin_noise_estimator.c
+++ b/tests/test_martin_noise_estimator.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Martin (2001) Minimum Statistics Noise Estimator
  */
 

--- a/tests/test_masking_veto.c
+++ b/tests/test_masking_veto.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Masking Veto
  */
 

--- a/tests/test_nlm_filter.c
+++ b/tests/test_nlm_filter.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for NLM Filter (Non-Local Means)
  */
 

--- a/tests/test_noise_floor_manager.c
+++ b/tests/test_noise_floor_manager.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Noise Floor Manager
  */
 

--- a/tests/test_noise_profile.c
+++ b/tests/test_noise_profile.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Noise Profile functionality
  */
 

--- a/tests/test_shared_utils.c
+++ b/tests/test_shared_utils.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Pre-estimation modules
  */
 

--- a/tests/test_specbleach_denoiser.c
+++ b/tests/test_specbleach_denoiser.c
@@ -27,7 +27,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdlib.h>
 #include <string.h>
 
-#include "shared/denoiser_logic/processing/hpss_filter.h"
 #include "specbleach_denoiser.h"
 
 #define ROLLING_MEAN 1
@@ -587,15 +586,15 @@ void test_specbleach_smoothing_transition_and_validation(void) {
   }
 
   // Transient during NLM mode: transient-mask loops in the NLM chain
-  params.hpss_enable = true;
+  params.transient_protection_enable = true;
   params.smoothing_mode = SPECBLEACH_SMOOTHING_NLM_2D;
   TEST_ASSERT(specbleach_denoiser_load_parameters(handle, &params,
                                                   sizeof(params)) == true,
-              "Loading NLM with HPSS should succeed");
+              "Loading NLM with transient protection should succeed");
   for (int f = 0; f < 15; ++f) {
     specbleach_denoiser_process(handle, 1024, transient_like, out_buf);
   }
-  params.hpss_enable = false;
+  params.transient_protection_enable = false;
 
   // Profile with mismatched size must be rejected
   TEST_ASSERT(specbleach_denoiser_load_noise_profile_for_mode(
@@ -923,14 +922,14 @@ int main(void) {
   float peak_freqs[10];
   specbleach_denoiser_get_tonal_peaks(h, peak_freqs, 10);
 
-  // Process with tonal reduction and HPSS enabled
+  // Process with tonal reduction and transient protection enabled
   float in_buf[1024] = {0};
   float out_buf[1024] = {0};
   SpecbleachDenoiserParameters t_params = {
       .learn_noise = SPECBLEACH_LEARN_OFF,
       .tonal_reduction_gain = 0.5f,
       .reduction_gain = 0.1f,
-      .hpss_enable = true,
+      .transient_protection_enable = true,
   };
   specbleach_denoiser_load_parameters(h, &t_params, sizeof(t_params));
   specbleach_denoiser_process(h, 1024, in_buf, out_buf);
@@ -964,23 +963,23 @@ int main(void) {
       "Load with curve bias should succeed");
   specbleach_denoiser_process(h, 1024, transient_buf, out_buf);
 
-  // Switch HPSS modes and verify latency
+  // Switch transient protection modes and verify latency
   t_params.residual_listen = 0;
   t_params.reduction_curve_enabled = false;
   t_params.reduction_curve_bias = NULL;
   t_params.reduction_curve_size = 0;
   free(curve_bias);
 
-  t_params.hpss_enable = false;
+  t_params.transient_protection_enable = false;
   specbleach_denoiser_load_parameters(h, &t_params, sizeof(t_params));
   specbleach_denoiser_process(h, 1024, in_buf, out_buf);
   uint32_t lat0 = specbleach_denoiser_get_latency(h);
 
-  t_params.hpss_enable = true;
+  t_params.transient_protection_enable = true;
   specbleach_denoiser_load_parameters(h, &t_params, sizeof(t_params));
   specbleach_denoiser_process(h, 1024, in_buf, out_buf);
   uint32_t lat1 = specbleach_denoiser_get_latency(h);
-  TEST_ASSERT(lat1 == lat0, "Sliding HPSS introduces zero lookahead latency");
+  TEST_ASSERT(lat1 == lat0, "Transient protection adds no lookahead latency");
 
   // Verify NULL handle protections
   TEST_ASSERT(specbleach_denoiser_get_latency(NULL) == 0, "NULL latency");

--- a/tests/test_specbleach_denoiser.c
+++ b/tests/test_specbleach_denoiser.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for SpectralBleach Denoiser API functions
  */
 

--- a/tests/test_spectral_circular_buffer.c
+++ b/tests/test_spectral_circular_buffer.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for the SbSpectralCircularBuffer module
  */
 

--- a/tests/test_spectral_whitening.c
+++ b/tests/test_spectral_whitening.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Spectral Whitening
  */
 

--- a/tests/test_spp_mmse_noise_estimator.c
+++ b/tests/test_spp_mmse_noise_estimator.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for SPP-MMSE Noise Estimator
  */
 

--- a/tests/test_suppression_engine.c
+++ b/tests/test_suppression_engine.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for Suppression Engine
  */
 

--- a/tests/test_tonal_detector.c
+++ b/tests/test_tonal_detector.c
@@ -1,6 +1,26 @@
 /*
 libspecbleach - A spectral processing library
 
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
+libspecbleach - A spectral processing library
+
 Test suite for the frequency-adaptive tonal detector with parabolic
 interpolation.
 */

--- a/tests/test_tonal_reducer.c
+++ b/tests/test_tonal_reducer.c
@@ -1,5 +1,25 @@
 /*
 libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
+libspecbleach - A spectral processing library
 Test suite for the Tonal Reducer module.
 */
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,4 +1,24 @@
 /*
+libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/*
  * Unit tests for utility functions
  */
 


### PR DESCRIPTION
Release preparation for 0.4.0:

- CHANGELOG rewritten as [0.4.0] - 2026-09-07 covering all post-0.3.1 work (type-safe C API, PFFFT migration, OpenMP removal, DFTT stage, Wiener knee, HPSS, quality suite, low-latency init flags)
- LGPL headers added to 22 test files
- Honest RT contract wording for 2D NLM worker-pool blocking
- Stale soname reference fixed

Verification: full ctest 38/38 green.