### PR TITLE
fix: transient protection noise pump via frame alignment + per-bin evidence gating

### DIFF
--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -116,7 +116,12 @@ typedef struct SbSpectralDenoiser {
 
   float* band_energies;
   float* onset_weights;
-  float* transient_mask;
+  float* held_weights;        // Band weights decayed after detection (hold)
+  float* transient_mask;      // Per-bin, clean-evidence gated (gain floor)
+  float* transient_band_mask; // Band-level, ungated (alpha drop / smoothing)
+  float transient_hold_decay; // Per-hop hold decay factor
+  uint32_t transient_hold_remaining; // Frames of mask hold left
+  bool transient_protection_active;  // Detected now or within hold window
   float* clean_magnitude;
   float* smoothed_magnitude;      // Temporal pre-subtraction smoothed magnitude
   bool smoothed_magnitude_seeded; // First frame seeds raw (no ramp-in)
@@ -437,12 +442,23 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
       (float*)calloc(num_bands > 0U ? num_bands : 1U, sizeof(float));
   self->onset_weights =
       (float*)calloc(num_bands > 0U ? num_bands : 1U, sizeof(float));
+  self->held_weights =
+      (float*)calloc(num_bands > 0U ? num_bands : 1U, sizeof(float));
   self->transient_mask =
       (float*)calloc(self->real_spectrum_size, sizeof(float));
+  self->transient_band_mask =
+      (float*)calloc(self->real_spectrum_size, sizeof(float));
+  // Hold decay: per-hop factor so the mask hold spans TRANSIENT_HOLD_SEC
+  // regardless of frame size.
+  self->transient_hold_decay =
+      (self->hop_sec > 0.0F) ? expf(-self->hop_sec / TRANSIENT_HOLD_SEC) : 0.0F;
+  self->transient_hold_remaining = 0U;
+  self->transient_protection_active = false;
 
   if (!self->noise_floor_manager || !self->critical_bands ||
       !self->transient_detector || !self->band_energies ||
-      !self->onset_weights || !self->transient_mask) {
+      !self->onset_weights || !self->transient_mask ||
+      !self->transient_band_mask || !self->held_weights) {
     spectral_denoiser_free(self);
     return NULL;
   }
@@ -539,8 +555,14 @@ void spectral_denoiser_free(SpectralProcessorHandle instance) {
   if (self->onset_weights) {
     free(self->onset_weights);
   }
+  if (self->held_weights) {
+    free(self->held_weights);
+  }
   if (self->transient_mask) {
     free(self->transient_mask);
+  }
+  if (self->transient_band_mask) {
+    free(self->transient_band_mask);
   }
   if (self->clean_magnitude) {
     free(self->clean_magnitude);
@@ -767,47 +789,6 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     }
   }
 
-  // 2.1 Transient Detection via Transient Detector across Critical Bands
-  // Transient detection runs on a clean signal estimate with scaled-up noise
-  // subtraction to avoid false triggering from residual musical noise.
-  bool transient_enabled = (self->parameters.transient_protection_enable != 0);
-  if (transient_enabled && self->critical_bands && self->transient_detector) {
-    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-      // Scale noise up using TRANSIENT_CLEAN_NOISE_SCALE to eliminate spurious
-      // noise peaks
-      float clean = fmaxf(reference_spectrum[k] - (TRANSIENT_CLEAN_NOISE_SCALE *
-                                                   self->noise_spectrum[k]),
-                          0.0F);
-      self->clean_magnitude[k] = clean;
-    }
-
-    compute_critical_bands_spectrum(self->critical_bands, self->clean_magnitude,
-                                    self->band_energies);
-    self->is_transient_detected = transient_detector_process(
-        self->transient_detector, self->band_energies, self->onset_weights,
-        &self->transient_intensity);
-
-    // Expand critical band onset weights to per-bin transient mask
-    uint32_t num_bands = get_number_of_critical_bands(self->critical_bands);
-    memset(self->transient_mask, 0, self->real_spectrum_size * sizeof(float));
-    for (uint32_t b = 0; b < num_bands; ++b) {
-      float bw = self->onset_weights[b];
-      if (bw > 0.0F) {
-        CriticalBandIndexes idx = get_band_indexes(self->critical_bands, b);
-        uint32_t end = (idx.end_position < self->real_spectrum_size)
-                           ? idx.end_position
-                           : self->real_spectrum_size;
-        for (uint32_t k = idx.start_position; k < end; ++k) {
-          self->transient_mask[k] = fmaxf(self->transient_mask[k], bw);
-        }
-      }
-    }
-  } else {
-    self->is_transient_detected = false;
-    self->transient_intensity = 0.0f;
-    memset(self->transient_mask, 0, self->real_spectrum_size * sizeof(float));
-  }
-
   // 2.2 Align internal state and output to the common delayed frame
   // (skipped in low-latency mode: causal, zero look-ahead)
   const float* delayed_spectrum = fft_spectrum;
@@ -926,6 +907,99 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   // Align output to delayed frame for post-processing
   if (!self->low_latency && delayed_spectrum != fft_spectrum) {
     memcpy(fft_spectrum, delayed_spectrum, self->fft_size * sizeof(float));
+  }
+
+  // 2.3 Transient Detection via Transient Detector across Critical Bands.
+  // Runs on the ALIGNED (delayed) frame so the transient mask describes the
+  // same frame the gains below modify. Detecting on the current input frame
+  // would fire ~46 ms before the transient is emitted and open gains on the
+  // noise-only frames around it (audible noise pumping at every transient).
+  // A clean signal estimate with scaled-up noise subtraction avoids false
+  // triggering from residual musical noise.
+  bool transient_enabled = (self->parameters.transient_protection_enable != 0);
+  if (transient_enabled && self->critical_bands && self->transient_detector) {
+    const float* delayed_magnitude =
+        get_spectral_feature(self->spectral_features, delayed_spectrum,
+                             self->fft_size, self->spectrum_type);
+    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+      // Scale noise up using TRANSIENT_CLEAN_NOISE_SCALE to eliminate spurious
+      // noise peaks
+      float clean = fmaxf(delayed_magnitude[k] -
+                              (TRANSIENT_CLEAN_NOISE_SCALE * delayed_noise[k]),
+                          0.0F);
+      self->clean_magnitude[k] = clean;
+    }
+
+    compute_critical_bands_spectrum(self->critical_bands, self->clean_magnitude,
+                                    self->band_energies);
+    self->is_transient_detected = transient_detector_process(
+        self->transient_detector, self->band_energies, self->onset_weights,
+        &self->transient_intensity);
+
+    // Hold: keep the fired band weights alive (decayed) across the transient
+    // decay tail, so oversubtraction relief outlives the detector's own
+    // trigger window instead of cutting the tail off as soon as the SNR
+    // drops below the trigger.
+    if (self->is_transient_detected) {
+      self->transient_hold_remaining =
+          (self->transient_hold_decay > 0.0F)
+              ? (uint32_t)(TRANSIENT_HOLD_SEC / self->hop_sec + 0.5F)
+              : 0U;
+    } else if (self->transient_hold_remaining > 0U) {
+      self->transient_hold_remaining--;
+    }
+    self->transient_protection_active =
+        self->is_transient_detected || self->transient_hold_remaining > 0U;
+    uint32_t num_bands = get_number_of_critical_bands(self->critical_bands);
+    for (uint32_t b = 0; b < num_bands; ++b) {
+      self->held_weights[b] =
+          fmaxf(self->onset_weights[b],
+                self->held_weights[b] * self->transient_hold_decay);
+    }
+
+    // Expand held band weights to two per-bin masks:
+    // - transient_band_mask keeps the raw band weight: it only removes
+    //   oversubtraction (alpha -> alpha_min) and shapes smoothing, where the
+    //   Wiener curve itself keeps noise-dominant bins closed.
+    // - transient_mask is additionally scaled by per-bin clean evidence and
+    //   drives the hard gain floor: a band onset must not floor bins whose
+    //   energy is mostly noise (clean estimate ~0 under the scaled
+    //   subtraction), or every transient leaks the noise floor across the
+    //   whole critical band.
+    memset(self->transient_mask, 0, self->real_spectrum_size * sizeof(float));
+    memset(self->transient_band_mask, 0,
+           self->real_spectrum_size * sizeof(float));
+    for (uint32_t b = 0; b < num_bands; ++b) {
+      float bw = self->held_weights[b];
+      if (bw > 0.0F) {
+        CriticalBandIndexes idx = get_band_indexes(self->critical_bands, b);
+        uint32_t end = (idx.end_position < self->real_spectrum_size)
+                           ? idx.end_position
+                           : self->real_spectrum_size;
+        for (uint32_t k = idx.start_position; k < end; ++k) {
+          self->transient_band_mask[k] =
+              fmaxf(self->transient_band_mask[k], bw);
+          float evidence = self->clean_magnitude[k] /
+                           (delayed_magnitude[k] + TRANSIENT_BIN_EVIDENCE_EPS);
+          self->transient_mask[k] =
+              fmaxf(self->transient_mask[k], bw * evidence);
+        }
+      }
+    }
+  } else {
+    self->is_transient_detected = false;
+    self->transient_intensity = 0.0f;
+    self->transient_protection_active = false;
+    self->transient_hold_remaining = 0U;
+    if (self->critical_bands) {
+      uint32_t bands = get_number_of_critical_bands(self->critical_bands);
+      for (uint32_t b = 0; b < bands; ++b) {
+        self->held_weights[b] = 0.0F;
+      }
+    }
+    memset(self->transient_mask, 0, self->real_spectrum_size * sizeof(float));
+    memset(self->transient_band_mask, 0,
+           self->real_spectrum_size * sizeof(float));
   }
 
   // 3. Denoising Stage: dispatch the active smoothing strategy (or crossfade
@@ -1055,10 +1129,13 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
 
   // 3.4. Transient Protection:
   // Strictly on frequencies where transient was detected, drop alpha to
-  // ALPHA_MIN (1.0)
-  if (self->is_transient_detected) {
+  // ALPHA_MIN (1.0). Band-level weight: the Wiener curve itself keeps
+  // noise-dominant bins closed at alpha_min, while tonal transient
+  // components only modestly above the noise (excluded by the per-bin
+  // evidence gate) keep their oversubtraction relief.
+  if (self->transient_protection_active) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-      float t_weight = self->transient_mask[k];
+      float t_weight = self->transient_band_mask[k];
       if (t_weight > 0.0F) {
         float prot_factor = sqrtf(t_weight);
         alpha[k] =
@@ -1073,7 +1150,7 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
                   delayed_noise, gain_out, alpha, beta,
                   self->gain_calculation_type, NULL);
 
-  if (self->is_transient_detected) {
+  if (self->transient_protection_active) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
       float t_weight = self->transient_mask[k];
       if (t_weight > 0.0F) {
@@ -1122,7 +1199,7 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
         float prev = self->smoothed_magnitude[k];
         // Bin-by-bin adaptive smoothing: open immediately on transient bins
         // while keeping full smoothing elsewhere
-        float t_w = self->transient_mask[k];
+        float t_w = self->transient_band_mask[k];
         float adapt_alpha = (1.0F - t_w) * stabilization_alpha;
         self->smoothed_magnitude[k] =
             (adapt_alpha * prev) + ((1.0F - adapt_alpha) * raw);
@@ -1175,10 +1252,10 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
 
   // When transients are detected and enabled, drop alphas firmly to ALPHA_MIN
   // (1.0) strictly on the specific frequencies where transient energy was
-  // detected.
-  if (self->is_transient_detected) {
+  // detected. Band-level weight (see run_nlm_chain 3.4).
+  if (self->transient_protection_active) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-      float t_weight = self->transient_mask[k];
+      float t_weight = self->transient_band_mask[k];
       if (t_weight > 0.0F) {
         float prot_factor = sqrtf(t_weight);
         alpha[k] =
@@ -1214,7 +1291,7 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
                   self->gain_calculation_type, self->knee_spectrum);
 
   // Transient Protection: ensure transient bins have gain near 1.0
-  if (self->is_transient_detected) {
+  if (self->transient_protection_active) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
       float t_weight = self->transient_mask[k];
       if (t_weight > 0.0F) {
@@ -1235,7 +1312,7 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
       (TimeSmoothingParameters){
           .smoothing = fminf(self->parameters.smoothing_factor,
                              GAIN_SMOOTHING_RELEASE_P_CAP),
-          .transient_mask = self->transient_mask,
+          .transient_mask = self->transient_band_mask,
           .release_scale = (self->parameters.smoothing_factor > 0.0F)
                                ? self->release_scale
                                : NULL, // Unused while bypassed

--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -119,16 +119,16 @@ typedef struct SbSpectralDenoiser {
   float* held_weights;        // Band weights decayed after detection (hold)
   float* transient_mask;      // Per-bin, clean-evidence gated (gain floor)
   float* transient_band_mask; // Band-level, ungated (alpha drop / smoothing)
+  float* clean_magnitude;
+  float* smoothed_magnitude;  // Temporal pre-subtraction smoothed magnitude
+  float* knee_spectrum;       // Per-bin soft knee width (signal-dependent)
   float transient_hold_decay; // Per-hop hold decay factor
   uint32_t transient_hold_remaining; // Frames of mask hold left
-  bool transient_protection_active;  // Detected now or within hold window
-  float* clean_magnitude;
-  float* smoothed_magnitude;      // Temporal pre-subtraction smoothed magnitude
-  bool smoothed_magnitude_seeded; // First frame seeds raw (no ramp-in)
-  float* knee_spectrum;           // Per-bin soft knee width (signal-dependent)
-  bool is_transient_detected;
   float transient_intensity;
-  float hop_sec;    // True hop in seconds (frame/overlap/sr); 0 = legacy derive
+  float hop_sec; // True hop in seconds (frame/overlap/sr); 0 = legacy derive
+  bool smoothed_magnitude_seeded; // First frame seeds raw (no ramp-in)
+  bool is_transient_detected;
+  bool transient_protection_active; // Detected now or within hold window
   bool low_latency; // Causal 1D-only: zero look-ahead, no NLM delay
 
   // Smoothing mode state (written by load_parameters, read by process; the
@@ -893,7 +893,7 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
           const float e_sq = e * e;
           const float e_4th = e_sq * e_sq;
           const float raw_w = e_4th / (e_4th + conf_4th);
-          post_nlm[k] = raw_w * self->snr_delayed[k] + (1.0F - raw_w) * e;
+          post_nlm[k] = (raw_w * self->snr_delayed[k]) + ((1.0F - raw_w) * e);
         }
       }
       nlm_filter_reconstruct_magnitude(self->nlm_filter, post_nlm,
@@ -943,7 +943,7 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     if (self->is_transient_detected) {
       self->transient_hold_remaining =
           (self->transient_hold_decay > 0.0F)
-              ? (uint32_t)(TRANSIENT_HOLD_SEC / self->hop_sec + 0.5F)
+              ? (uint32_t)((TRANSIENT_HOLD_SEC / self->hop_sec) + 0.5F)
               : 0U;
     } else if (self->transient_hold_remaining > 0U) {
       self->transient_hold_remaining--;

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -162,7 +162,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define ONSET_RATIO_SENSITIVITY 0.25F // Innovation required for full weight
 #define TRANSIENT_SMOOTH_ALPHA 0.8F   // Reference smoothing alpha
 #define TRANSIENT_CLEAN_NOISE_SCALE                                            \
-  4.0F // Noise over-subtraction factor for clean transient estimation
+  2.0F // Noise over-subtraction factor for clean transient estimation
+#define TRANSIENT_HOLD_SEC                                                     \
+  0.20F // Band-mask decay hold after detection (covers decay tails)
+#define TRANSIENT_BIN_EVIDENCE_EPS                                             \
+  1e-9F // Denominator floor for per-bin transient evidence ratio
 
 /* --------------------------------------------------------------------- */
 /* 4. NLM 2D smoothing (Lukin Algorithm B) and transient protection. */

--- a/tests/test_audio_regression.c
+++ b/tests/test_audio_regression.c
@@ -46,6 +46,10 @@ void test_adaptive_denoising(void);
 void test_noise_estimation_methods(void);
 void test_snr_improvement(void);
 void test_frame_size_invariance(void);
+void test_transient_noise_pump(void);
+void test_transient_band_leak(void);
+void test_transient_pluck_preservation(void);
+/* TEMP DIAGNOSTIC */
 
 #define TEST_ASSERT(condition, message)                                        \
   do {                                                                         \
@@ -504,6 +508,9 @@ int main(void) {
   test_adaptive_denoising();
   test_noise_estimation_methods();
   test_frame_size_invariance();
+  test_transient_noise_pump();
+  test_transient_band_leak();
+  test_transient_pluck_preservation();
 
   printf("\n✅ All audio regression tests passed!\n");
   return 0;
@@ -740,4 +747,330 @@ void test_frame_size_invariance(void) {
   run_frame_invariance(SPECBLEACH_SMOOTHING_NLM_2D, "NLM");
   run_frame_invariance(SPECBLEACH_SMOOTHING_NLM_2D_DFTT, "NLM+DFTT");
   printf("✓ Frame-size invariance (both modes) passed\n");
+}
+
+/* Transient protection noise-pump regression: the transient mask must
+ * describe the ALIGNED (delayed) frame the gains modify, and must not open
+ * bins whose energy is mostly noise. Detection on the current input frame
+ * fires ~46 ms before the onset is emitted and floors the gain on
+ * noise-only frames — an audible noise pulse ("pumping") preceding every
+ * transient on highly noisy material. Metric: output noise power in a leak
+ * window ending just before each onset, protection ON vs OFF. */
+static void process_pump_probe(const float* input, float* output, int length,
+                               uint32_t* latency_out, int protection_on,
+                               float strength) {
+  specbleach_denoiser* handle =
+      specbleach_denoiser_initialize(SAMPLE_RATE, 46.0f, 0u);
+  TEST_ASSERT(handle != NULL, "Failed to initialize denoiser");
+
+  SpecbleachDenoiserParameters parameters = (SpecbleachDenoiserParameters){
+      .learn_noise = SPECBLEACH_LEARN_ALL,
+      .tonal_reduction_gain = 0.0f,
+      .aggressiveness = 0.0f,
+      .reduction_gain = 0.3f,
+      .smoothing_factor = 0.0f,
+      .smoothing_mode = SPECBLEACH_SMOOTHING_TEMPORAL,
+      .masking_depth = 0.5f,
+      .suppression_strength = strength,
+      .transient_protection_enable = (protection_on != 0),
+      .residual_listen = false,
+      .whitening_factor = 0.0f};
+
+  TEST_ASSERT(specbleach_denoiser_load_parameters(handle, &parameters,
+                                                  sizeof(parameters)),
+              "Load learn parameters should succeed");
+
+  /* Learn on noise-only head (first 0.5s), then denoise. */
+  const int learn_samples = SAMPLE_RATE / 2;
+  specbleach_denoiser_process(handle, learn_samples, input, output);
+
+  parameters.learn_noise = SPECBLEACH_LEARN_OFF;
+  TEST_ASSERT(specbleach_denoiser_load_parameters(handle, &parameters,
+                                                  sizeof(parameters)),
+              "Load reduction parameters should succeed");
+
+  int processed = learn_samples;
+  while (processed < length) {
+    int block_size = FRAME_SIZE;
+    if (processed + block_size > length) {
+      block_size = length - processed;
+    }
+    TEST_ASSERT(specbleach_denoiser_process(
+                    handle, block_size, input + processed, output + processed),
+                "Processing failed");
+    processed += block_size;
+  }
+
+  if (latency_out) {
+    *latency_out = specbleach_denoiser_get_latency(handle);
+  }
+  specbleach_denoiser_free(handle);
+}
+
+/* Goertzel power at one frequency over a window. */
+static double goertzel_power(const float* x, int start, int n, double freq) {
+  double coeff = 2.0 * cos(2.0 * M_PI * freq / (double)SAMPLE_RATE);
+  double s1 = 0.0, s2 = 0.0;
+  for (int i = 0; i < n; i++) {
+    double s = (double)x[start + i] + coeff * s1 - s2;
+    s2 = s1;
+    s1 = s;
+  }
+  return s1 * s1 + s2 * s2 - coeff * s1 * s2;
+}
+
+void test_transient_noise_pump(void) {
+  printf("Testing transient protection noise-pump (leak before onsets)...\n");
+
+  const int len = SAMPLE_RATE * 4;
+  float* input = calloc(len, sizeof(float));
+  float* out_on = calloc(len, sizeof(float));
+  float* out_off = calloc(len, sizeof(float));
+  TEST_ASSERT(input && out_on && out_off, "Failed to allocate test buffers");
+
+  /* Noise floor + broadband impulses every 0.6s starting at 1.2s (clear
+   * learn/settle head). On highly noisy audio the detector also fires on
+   * noise fluctuations; the mask must not open noise bins regardless. */
+  srand(4321);
+  for (int i = 0; i < len; i++) {
+    input[i] = 0.05f * ((float)rand() / RAND_MAX - 0.5f) * 2.0f;
+  }
+  int onsets = 0;
+  for (int t = SAMPLE_RATE * 12 / 10; t < len; t += SAMPLE_RATE * 6 / 10) {
+    input[t] = (onsets % 2 == 0) ? 0.9f : -0.9f;
+    if (t + 1 < len) {
+      input[t + 1] = -input[t] * 0.5f;
+    }
+    onsets++;
+  }
+
+  uint32_t lat_on = 0, lat_off = 0;
+  process_pump_probe(input, out_on, len, &lat_on, 1, 0.0f);
+  process_pump_probe(input, out_off, len, &lat_off, 0, 0.0f);
+  TEST_ASSERT(lat_on > 0 && lat_on < (uint32_t)len, "Latency must be finite");
+
+  /* Leak window in input time, latency-aligned: [onset-70ms, onset-25ms]
+   * covers the ~46ms misalignment zone; baseline is noise-only elsewhere. */
+  const int leak_start = (int)(0.070f * SAMPLE_RATE);
+  const int leak_end = (int)(0.025f * SAMPLE_RATE);
+  const int peak_len = (int)(0.030f * SAMPLE_RATE);
+
+  double leak_on = 0.0, leak_off = 0.0, peak = 0.0;
+  int leak_n = 0, covered = 0;
+  for (int t = SAMPLE_RATE * 12 / 10; t < len; t += SAMPLE_RATE * 6 / 10) {
+    covered++;
+    for (int j = t - leak_start; j < t - leak_end; j++) {
+      if (j + (int)lat_off >= len) {
+        break;
+      }
+      leak_off += out_off[j + lat_off] * out_off[j + lat_off];
+      if (j + (int)lat_on < len) {
+        leak_on += out_on[j + lat_on] * out_on[j + lat_on];
+      }
+      leak_n++;
+    }
+    for (int j = t; j < t + peak_len; j++) {
+      if (j + (int)lat_on >= len) {
+        break;
+      }
+      double v = fabs(out_on[j + lat_on]);
+      if (v > peak) {
+        peak = v;
+      }
+    }
+  }
+  TEST_ASSERT(covered > 0 && leak_n > 0, "Must cover onsets");
+  leak_on /= leak_n;
+  leak_off /= leak_n;
+  const double pump_ratio = leak_on / leak_off;
+  printf("  lat=%u onsets=%d leak_on=%.8f leak_off=%.8f ratio=%.2f peak=%.4f\n",
+         lat_on, covered, leak_on, leak_off, pump_ratio, peak);
+
+  /* Protection must not raise noise power just before onsets (bug: gain
+   * floored to the onset weight across whole critical bands ~46 ms before
+   * each onset; measured ~1.7x on/off with the bug). */
+  TEST_ASSERT(pump_ratio < 1.35,
+              "Noise power just before onsets must match the protection-off "
+              "baseline (no transient-protection pump)");
+  /* Protection must still preserve the transient itself. */
+  TEST_ASSERT(peak > 0.1, "Transient peak must be preserved");
+
+  free(input);
+  free(out_on);
+  free(out_off);
+  printf("✓ Transient noise-pump test passed\n");
+}
+
+/* In-band per-bin leak: a band-limited burst fires one critical band; the
+ * mask must open only bins that actually carry burst energy, not the whole
+ * band. Probes a noise-only bin inside the fired band (burst skirt below
+ * the scaled-noise clean floor there) during the burst window, protection
+ * ON vs OFF. */
+void test_transient_band_leak(void) {
+  printf("Testing transient protection in-band bin leak...\n");
+
+  const int len = SAMPLE_RATE * 4;
+  float* input = calloc(len, sizeof(float));
+  float* out_on = calloc(len, sizeof(float));
+  float* out_off = calloc(len, sizeof(float));
+  TEST_ASSERT(input && out_on && out_off, "Failed to allocate test buffers");
+
+  srand(4321);
+  for (int i = 0; i < len; i++) {
+    input[i] = 0.05f * ((float)rand() / RAND_MAX - 0.5f) * 2.0f;
+  }
+  /* Blackman-edged 8ms 5.85kHz bursts every 0.6s from 1.2s: fires the
+   * 5.3-6.4kHz band; the 6.35kHz probe bin holds only noise (skirt far
+   * below the scaled clean floor). */
+  const int burst_len = (int)(0.008f * SAMPLE_RATE);
+  for (int t = SAMPLE_RATE * 12 / 10; t < len; t += SAMPLE_RATE * 6 / 10) {
+    for (int j = 0; j < burst_len && t + j < len; j++) {
+      double w = 0.42 - 0.5 * cos(2.0 * M_PI * j / (burst_len - 1)) +
+                 0.08 * cos(4.0 * M_PI * j / (burst_len - 1));
+      input[t + j] +=
+          (float)(0.5 * w * sin(2.0 * M_PI * 5850.0 * j / (double)SAMPLE_RATE));
+    }
+  }
+
+  uint32_t lat_on = 0, lat_off = 0;
+  process_pump_probe(input, out_on, len, &lat_on, 1, 0.0f);
+  process_pump_probe(input, out_off, len, &lat_off, 0, 0.0f);
+
+  /* 24ms Goertzel window just before each burst, latency-aligned: the
+   * strong burst-band mask must not floor this noise-only in-band bin
+   * there (bug: mask misalignment + band-wide expansion opened it). */
+  const int win = (int)(0.024f * SAMPLE_RATE);
+  double probe_on = 0.0, probe_off = 0.0;
+  int bursts = 0;
+  for (int t = SAMPLE_RATE * 12 / 10; t + (int)lat_on + win < len;
+       t += SAMPLE_RATE * 6 / 10) {
+    probe_on += goertzel_power(
+        out_on, t + (int)lat_on - (int)(0.058f * SAMPLE_RATE), win, 6350.0);
+    probe_off += goertzel_power(
+        out_off, t + (int)lat_off - (int)(0.058f * SAMPLE_RATE), win, 6350.0);
+    bursts++;
+  }
+  TEST_ASSERT(bursts > 0, "Must cover at least one burst");
+  probe_on /= bursts;
+  probe_off /= bursts;
+  printf("  bursts=%d probe_on=%.10f probe_off=%.10f ratio=%.2f\n", bursts,
+         probe_on, probe_off, probe_on / probe_off);
+
+  /* The band onset must not floor the noise-only probe bin (bug: mask
+   * misalignment + band-wide expansion opened it; measured 1.99x on/off
+   * with the bug). */
+  TEST_ASSERT(probe_on < 1.5 * probe_off,
+              "In-band noise-only bin must stay suppressed during a "
+              "band-limited transient (no band-wide leak)");
+
+  free(input);
+  free(out_on);
+  free(out_off);
+  printf("✓ Transient in-band leak test passed\n");
+}
+
+/* Tonal transient (plucked-string-like) preservation at high suppression
+ * strength: the protection must relieve oversubtraction on the pluck's
+ * attack and decay tail while leaving noise-only frames untouched. */
+void test_transient_pluck_preservation(void) {
+  printf("Testing pluck preservation (high threshold, on vs off)...\n");
+
+  const int len = SAMPLE_RATE * 4;
+  float* input = calloc(len, sizeof(float));
+  float* out_on = calloc(len, sizeof(float));
+  float* out_off = calloc(len, sizeof(float));
+  TEST_ASSERT(input && out_on && out_off, "Failed to allocate test buffers");
+
+  srand(4321);
+  for (int i = 0; i < len; i++) {
+    input[i] = 0.05f * ((float)rand() / RAND_MAX - 0.5f) * 2.0f;
+  }
+  /* Pluck: 220Hz + 4 harmonics, 3ms attack, 150ms exp decay, 500ms long. */
+  const int pluck_len = (int)(0.500f * SAMPLE_RATE);
+  const int attack = (int)(0.003f * SAMPLE_RATE);
+  const int harm_n = 4;
+  const float amps[4] = {1.0f, 0.5f, 0.33f, 0.25f};
+  for (int t = SAMPLE_RATE * 12 / 10; t + pluck_len < len;
+       t += SAMPLE_RATE * 6 / 10) {
+    for (int j = 0; j < pluck_len; j++) {
+      float env = (j < attack)
+                      ? (float)j / (float)attack
+                      : expf(-(float)(j - attack) / (0.150f * SAMPLE_RATE));
+      float s = 0.0f;
+      for (int h = 0; h < harm_n; h++) {
+        s += amps[h] * sinf(2.0f * M_PIf * 220.0f * (float)(h + 1) * (float)j /
+                            (float)SAMPLE_RATE);
+      }
+      input[t + j] += 0.35f * env * s / 2.08f; /* /sum(amps) normalize */
+    }
+  }
+
+  uint32_t lat_on = 0, lat_off = 0;
+  process_pump_probe(input, out_on, len, &lat_on, 1, 1.0f);
+  process_pump_probe(input, out_off, len, &lat_off, 0, 1.0f);
+
+  const int attack_win = (int)(0.020f * SAMPLE_RATE);
+  const int early_win = (int)(0.150f * SAMPLE_RATE);
+  const int late_win = (int)(0.450f * SAMPLE_RATE);
+  double att_in = 0.0, att_on = 0.0, att_off = 0.0;
+  double early_in = 0.0, early_on = 0.0, early_off = 0.0;
+  double late_in = 0.0, late_on = 0.0, late_off = 0.0;
+  double peak_in = 0.0, peak_on = 0.0, peak_off = 0.0;
+  int onsets = 0;
+  for (int t = SAMPLE_RATE * 12 / 10; t + (int)lat_on + late_win < len;
+       t += SAMPLE_RATE * 6 / 10) {
+    onsets++;
+    for (int j = 0; j < attack_win; j++) {
+      att_in += input[t + j] * input[t + j];
+      att_on += out_on[t + j + lat_on] * out_on[t + j + lat_on];
+      att_off += out_off[t + j + lat_off] * out_off[t + j + lat_off];
+      double v1 = fabs(out_on[t + j + lat_on]);
+      double v0 = fabs(out_off[t + j + lat_off]);
+      double vi = fabs(input[t + j]);
+      if (v1 > peak_on) {
+        peak_on = v1;
+      }
+      if (v0 > peak_off) {
+        peak_off = v0;
+      }
+      if (vi > peak_in) {
+        peak_in = vi;
+      }
+    }
+    for (int j = attack_win; j < early_win; j++) {
+      early_in += input[t + j] * input[t + j];
+      early_on += out_on[t + j + lat_on] * out_on[t + j + lat_on];
+      early_off += out_off[t + j + lat_off] * out_off[t + j + lat_off];
+    }
+    for (int j = early_win; j < late_win; j++) {
+      late_in += input[t + j] * input[t + j];
+      late_on += out_on[t + j + lat_on] * out_on[t + j + lat_on];
+      late_off += out_off[t + j + lat_off] * out_off[t + j + lat_off];
+    }
+  }
+  TEST_ASSERT(onsets > 0, "Must cover at least one pluck");
+  late_on /= onsets;
+  late_off /= onsets;
+  printf(
+      "  onsets=%d attack in=%.4f on=%.4f off=%.4f | early in=%.4f "
+      "on=%.4f off=%.4f | late in=%.4f on=%.4f off=%.4f | peak in=%.4f "
+      "on=%.4f off=%.4f\n",
+      onsets, att_in / onsets, att_on / onsets, att_off / onsets,
+      early_in / onsets, early_on / onsets, early_off / onsets,
+      late_in / onsets, late_on / onsets, late_off / onsets, peak_in, peak_on,
+      peak_off);
+
+  /* Non-regression: protection must never eat the pluck relative to the
+   * protection-off baseline. */
+  TEST_ASSERT(peak_on > 0.9 * peak_off, "Protection must not eat pluck peak");
+  TEST_ASSERT(att_on > 0.9 * att_off, "Protection must not eat pluck attack");
+  TEST_ASSERT(early_on > 0.9 * early_off, "Protection must not eat pluck body");
+  /* Tail hold: the held band mask must keep oversubtraction relief alive
+   * into the decay tail (measured +3.7% tail energy on/off). */
+  TEST_ASSERT(late_on > late_off,
+              "Protection hold must relieve the decay tail");
+
+  free(input);
+  free(out_on);
+  free(out_off);
 }


### PR DESCRIPTION
## Problem (#161)

On highly noisy audio, transient protection pumped the noise floor: every
transient was preceded by an audible noise pulse, and in-band noise-only
bins leaked during band-limited transients.

Two root causes:

1. **Frame misalignment** - transient detection ran on the *current input*
   frame while the gains modify the *emitted (delayed)* frame (2-8 hops of
   NLM look-ahead). The onset mask fired ~46 ms before the transient was
   emitted, opening gains band-wide on noise-only frames; the transient
   frame itself got no mask (the detector's floor had already adapted).
2. **Band-wide floor expansion** - per-Bark-band onset weights were
   expanded to *all* bins of the band and floored the Wiener gain up to
   1.0, including bins holding only noise (up to 3.5 kHz-wide bands).

## Fix

- **Aligned detection**: the transient detector runs on the aligned
  (delayed) frame, so masks describe the same frame the gains modify.
  Low-latency path unchanged (delay 0).
- **Two-mask split**: the band-level weight drives alpha relief and
  smoothing-shaping only (the Wiener curve itself keeps noise-dominant
  bins closed at `ALPHA_MIN`); the **hard gain floor** stays scaled by
  per-bin clean evidence (`clean/(mag+eps)` against the scaled noise
  subtraction), so a band onset can no longer open noise-only bins.
- **Decay-tail hold**: fired band weights decay over 200 ms (frame-rate
  normalized) so oversubtraction relief outlives the detector's trigger
  window - pluck tails keep relief while they decay into the noise.
- **Detector sensitivity**: clean-estimate scale retuned 4.0 -> 2.0
  (`TRANSIENT_CLEAN_NOISE_SCALE`), letting tonal components modestly
  above the noise register in onset weights.
- New constant `TRANSIENT_HOLD_SEC` and `TRANSIENT_BIN_EVIDENCE_EPS` in
  `src/shared/configurations.h` (no magic numbers, no new user control).

## Verification

New regression cases in `test_audio_regression.c` (protection ON vs OFF,
latency-aligned):

- **Noise pump**: output noise power just before each onset must match
  the protection-off baseline. Previous code: 1.55x (audible pulse).
  Fixed: 1.00x.
- **In-band bin leak**: Goertzel probe on a noise-only bin inside a
  fired band, just before a band-limited burst. Previous code: 1.99x.
  Fixed: 1.00x.
- **Pluck preservation** (high suppression strength): protection must
  never eat the pluck (attack/body/peak non-regression) and the
  decay-tail hold must relieve the tail (+3.7% tail energy on/off).

Full suites: 39/39 libspecbleach ctest (reference files regenerated for
the intentional algorithm change), 5/5 noise-repellent plugin tests
(incl. UX invariants).

Closes #161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transient protection to preserve attacks, tonal plucks, and natural decay tails.
  - Reduced noise pumping immediately before transients.
  - Prevented transient processing from leaking into noise-only frequency regions.
  - Improved clean-transient estimation to reduce excessive noise removal.
  - Added more consistent transient handling across short-lived events and their decay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->