### PR TITLE
Parallel gain-path decoupling: tonal dual-path + transient relief as gain-domain branch

### DIFF
--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -91,7 +91,7 @@ typedef struct SbSpectralDenoiser {
   float* alpha_tonal; // Legacy combined-path scratch (tonal branch)
 #endif
   float* beta_b; // Undersubtraction factors (transition chain)
-#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+#if TRANSIENT_RELIEF_PARALLEL
   float* alpha_relief; // Relief-branch alpha (all ALPHA_MIN)
   float* gain_relief;  // Relief-branch preservation gain (parallel output)
 #endif
@@ -127,6 +127,7 @@ typedef struct SbSpectralDenoiser {
   // profiles ride along so the parallel tonal path describes the same tile)
   uint32_t layer_noise_bb;
   uint32_t layer_noise_tonal;
+  uint32_t layer_tonal_mask; // Mask aligned to the delayed noise_tonal layer
   float* band_energies;
   float* onset_weights;
   float* held_weights;        // Band weights decayed after detection (hold)
@@ -204,6 +205,11 @@ static void align_bypass_frame(SbSpectralDenoiser* self, float* fft_spectrum,
                                 self->noise_bb);
   spectral_circular_buffer_push(self->circular_buffer, self->layer_noise_tonal,
                                 self->noise_tonal);
+  const float* bypass_tonal_mask = tonal_reducer_get_mask(self->tonal_reducer);
+  if (bypass_tonal_mask) {
+    spectral_circular_buffer_push(self->circular_buffer, self->layer_tonal_mask,
+                                  bypass_tonal_mask);
+  }
   spectral_circular_buffer_push(self->circular_buffer, self->layer_smoothed,
                                 reference_spectrum);
   nlm_filter_calculate_snr(self->nlm_filter, reference_spectrum, self->noise_bb,
@@ -222,13 +228,15 @@ static void align_bypass_frame(SbSpectralDenoiser* self, float* fft_spectrum,
 static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
                           const float* smoothed_magnitude,
                           const float* delayed_noise_bb,
-                          const float* delayed_noise_tonal, uint32_t slot,
+                          const float* delayed_noise_tonal,
+                          const float* delayed_tonal_mask, uint32_t slot,
                           float* gain_out, float* alpha, float* beta);
 
 static void run_temporal_chain(SbSpectralDenoiser* self,
                                const float* delayed_fft,
                                const float* delayed_noise_bb,
-                               const float* delayed_noise_tonal, uint32_t slot,
+                               const float* delayed_noise_tonal,
+                               const float* delayed_tonal_mask, uint32_t slot,
                                float* gain_out, float* alpha, float* beta);
 
 static SpectralProcessorHandle spectral_denoiser_initialize_inner(
@@ -284,7 +292,7 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
   self->beta = (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->alpha_b = (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->beta_b = (float*)calloc(self->real_spectrum_size, sizeof(float));
-#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+#if TRANSIENT_RELIEF_PARALLEL
   self->alpha_relief = (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->gain_relief = (float*)calloc(self->fft_size, sizeof(float));
 #endif
@@ -306,7 +314,7 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
       !self->noise_spectrum_buffers[1] || !self->noise_bb ||
       !self->noise_tonal || !self->gain_tonal || !self->alpha || !self->beta ||
       !self->alpha_b || !self->beta_b ||
-#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+#if TRANSIENT_RELIEF_PARALLEL
       !self->alpha_relief || !self->gain_relief ||
 #endif
 #if !TONAL_DUAL_PATH
@@ -326,7 +334,7 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
                                        1.F);
   (void)initialize_spectrum_with_value(self->alpha_b, self->real_spectrum_size,
                                        1.F);
-#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+#if TRANSIENT_RELIEF_PARALLEL
   // Relief branch evaluates the plain Wiener curve (no oversubtraction)
   (void)initialize_spectrum_with_value(self->alpha_relief,
                                        self->real_spectrum_size, ALPHA_MIN);
@@ -357,11 +365,14 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
       self->circular_buffer, self->real_spectrum_size);
   self->layer_noise_tonal = spectral_circular_buffer_add_layer(
       self->circular_buffer, self->real_spectrum_size);
+  self->layer_tonal_mask = spectral_circular_buffer_add_layer(
+      self->circular_buffer, self->real_spectrum_size);
 
   if (self->layer_fft == 0xFFFFFFFFU || self->layer_noise == 0xFFFFFFFFU ||
       self->layer_smoothed == 0xFFFFFFFFU ||
       self->layer_noise_bb == 0xFFFFFFFFU ||
-      self->layer_noise_tonal == 0xFFFFFFFFU) {
+      self->layer_noise_tonal == 0xFFFFFFFFU ||
+      self->layer_tonal_mask == 0xFFFFFFFFU) {
     spectral_denoiser_free(self);
     return NULL;
   }
@@ -639,7 +650,7 @@ void spectral_denoiser_free(SpectralProcessorHandle instance) {
   free(self->beta);
   free(self->alpha_b);
   free(self->beta_b);
-#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+#if TRANSIENT_RELIEF_PARALLEL
   free(self->alpha_relief);
   free(self->gain_relief);
 #endif
@@ -738,6 +749,9 @@ bool load_reduction_parameters(SpectralProcessorHandle instance,
       self->pending_mode = self->previous_mode;
       self->previous_mode = outgoing;
       self->transition_pos = self->transition_frames - self->transition_pos;
+      // The chain-slot mapping is keyed on previous_mode, so the two tonal
+      // gain histories must swap along with the mode metadata.
+      tonal_reducer_swap_gain_slots(self->tonal_reducer);
     } else {
       self->pending_mode = requested;
     }
@@ -872,6 +886,7 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   const float* delayed_noise = self->noise_spectrum;
   const float* delayed_noise_bb = self->noise_bb;
   const float* delayed_noise_tonal = self->noise_tonal;
+  const float* delayed_tonal_mask = tonal_reducer_get_mask(self->tonal_reducer);
   const float* nlm_smoothed = NULL;
   if (!self->low_latency) {
     spectral_circular_buffer_push(self->circular_buffer, self->layer_fft,
@@ -882,6 +897,16 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
                                   self->noise_bb);
     spectral_circular_buffer_push(self->circular_buffer,
                                   self->layer_noise_tonal, self->noise_tonal);
+
+    // The tonal mask must ride with the residual it belongs to: the chains
+    // run on the delayed noise_tonal, so the mask they evaluate must be the
+    // one from that same frame, not the current one.
+    const float* current_tonal_mask =
+        tonal_reducer_get_mask(self->tonal_reducer);
+    if (current_tonal_mask) {
+      spectral_circular_buffer_push(self->circular_buffer,
+                                    self->layer_tonal_mask, current_tonal_mask);
+    }
 
     // Compute SNR for 2D filters using the broadband split (current frame)
     // and push frame. This keeps both NLM and BM3D histories rolling even in
@@ -926,6 +951,8 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
         self->circular_buffer, self->layer_noise_bb, nlm_delay);
     delayed_noise_tonal = spectral_circular_buffer_retrieve(
         self->circular_buffer, self->layer_noise_tonal, nlm_delay);
+    delayed_tonal_mask = spectral_circular_buffer_retrieve(
+        self->circular_buffer, self->layer_tonal_mask, nlm_delay);
 
     if (!delayed_spectrum) {
       delayed_spectrum = fft_spectrum;
@@ -938,6 +965,9 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     }
     if (!delayed_noise_tonal) {
       delayed_noise_tonal = self->noise_tonal;
+    }
+    if (!delayed_tonal_mask) {
+      delayed_tonal_mask = tonal_reducer_get_mask(self->tonal_reducer);
     }
 
     if (filter_ran) {
@@ -1106,18 +1136,18 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
 
     if (is_2d_family(self->previous_mode)) {
       (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise_bb,
-                          delayed_noise_tonal, 0U, gain_a, self->alpha,
-                          self->beta);
+                          delayed_noise_tonal, delayed_tonal_mask, 0U, gain_a,
+                          self->alpha, self->beta);
       run_temporal_chain(self, fft_spectrum, delayed_noise_bb,
-                         delayed_noise_tonal, 1U, gain_b, self->alpha_b,
-                         self->beta_b);
+                         delayed_noise_tonal, delayed_tonal_mask, 1U, gain_b,
+                         self->alpha_b, self->beta_b);
     } else {
       run_temporal_chain(self, fft_spectrum, delayed_noise_bb,
-                         delayed_noise_tonal, 0U, gain_a, self->alpha,
-                         self->beta);
+                         delayed_noise_tonal, delayed_tonal_mask, 0U, gain_a,
+                         self->alpha, self->beta);
       (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise_bb,
-                          delayed_noise_tonal, 1U, gain_b, self->alpha_b,
-                          self->beta_b);
+                          delayed_noise_tonal, delayed_tonal_mask, 1U, gain_b,
+                          self->alpha_b, self->beta_b);
     }
 
     for (uint32_t k = 0U; k < self->fft_size; ++k) {
@@ -1128,15 +1158,18 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     if (self->transition_pos >= self->transition_frames) {
       self->active_mode = self->pending_mode;
       self->in_transition = false;
+      // The incoming chain built its one-pole tonal gain state in slot 1 while
+      // fading in; it now becomes the active chain and reads slot 0.
+      tonal_reducer_promote_gain_slot(self->tonal_reducer);
     }
   } else if (!self->low_latency && is_2d_family(self->active_mode)) {
     (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise_bb,
-                        delayed_noise_tonal, 0U, gain_a, self->alpha,
-                        self->beta);
+                        delayed_noise_tonal, delayed_tonal_mask, 0U, gain_a,
+                        self->alpha, self->beta);
   } else {
     run_temporal_chain(self, fft_spectrum, delayed_noise_bb,
-                       delayed_noise_tonal, 0U, gain_a, self->alpha,
-                       self->beta);
+                       delayed_noise_tonal, delayed_tonal_mask, 0U, gain_a,
+                       self->alpha, self->beta);
   }
 
   // 4. Post-Processing: Final gain management and mixing
@@ -1187,7 +1220,8 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
 static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
                           const float* smoothed_magnitude,
                           const float* delayed_noise_bb,
-                          const float* delayed_noise_tonal, uint32_t slot,
+                          const float* delayed_noise_tonal,
+                          const float* delayed_tonal_mask, uint32_t slot,
                           float* gain_out, float* alpha, float* beta) {
   if (!smoothed_magnitude) {
     smoothed_magnitude = spectral_circular_buffer_retrieve(
@@ -1232,66 +1266,30 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
   }
 #endif
 
-#if !(TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL)
-  // Transient Protection: alpha relief on detected band onsets.
-  if (self->transient_protection_active) {
-    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-      float t_weight = self->transient_band_mask[k];
-      if (t_weight > 0.0F) {
-        float prot_factor = sqrtf(t_weight);
-        alpha[k] =
-            (alpha[k] * (1.0F - prot_factor)) + (ALPHA_MIN * prot_factor);
-        alpha[k] = fmaxf(ALPHA_MIN, alpha[k]);
-      }
-    }
-  }
-#endif
-
   // Broadband gain calculation: stationary tonal peaks are gone from the
   // profile, so the 2D-smoothed Wiener gain is a smooth field.
+  //
+  // The NLM/DFTT chain deliberately applies NO transient relief. The 2D filter
+  // already preserves onsets, and this chain has no gain smoother after
+  // calculate_gains, so any per-frame alpha relief / gain blend / hard floor
+  // lands in the final gain unsmoothed and injects musical noise across a
+  // note's sustain (measured ~1.5x sustain MNI on pluck+noise). Transient
+  // detection still runs globally for the UI; relief is applied only by the 1D
+  // temporal chain, where the gain smoother owns the result.
   calculate_gains(self->real_spectrum_size, self->fft_size, smoothed_magnitude,
                   delayed_noise_bb, gain_out, alpha, beta,
                   self->gain_calculation_type, NULL);
-
-#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
-  // Transient relief as a parallel GAIN-domain branch (see run_temporal_chain
-  // for rationale): blend the base gain toward the plain Wiener curve by the
-  // band protection weight.
-  if (self->transient_protection_active) {
-    calculate_gains(self->real_spectrum_size, self->fft_size,
-                    smoothed_magnitude, delayed_noise_bb, self->gain_relief,
-                    self->alpha_relief, beta, self->gain_calculation_type,
-                    NULL);
-    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-      const float pf = sqrtf(self->transient_band_mask[k]);
-      if (pf > 0.0F) {
-        gain_out[k] = ((1.0F - pf) * gain_out[k]) + (pf * self->gain_relief[k]);
-      }
-    }
-  }
-#endif
 
 #if TONAL_DUAL_PATH
   // Parallel tonal gain path + decision criterion. Ran on the same
   // smoothed magnitude so the min() compares like with like.
   tonal_reducer_compute_tonal_gains(
       self->tonal_reducer, slot, smoothed_magnitude, delayed_noise_tonal,
-      self->parameters.tonal_reduction, self->gain_tonal);
+      delayed_tonal_mask, self->parameters.tonal_reduction, self->gain_tonal);
   for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
     gain_out[k] = fminf(gain_out[k], self->gain_tonal[k]);
   }
 #endif
-
-  // Transient Protection re-asserted after the combine: a band onset must
-  // not be notched by a tonal bin underneath it.
-  if (self->transient_protection_active) {
-    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
-      float t_weight = self->transient_mask[k];
-      if (t_weight > 0.0F) {
-        gain_out[k] = fmaxf(gain_out[k], t_weight);
-      }
-    }
-  }
 
   return true;
 }
@@ -1304,7 +1302,8 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
 static void run_temporal_chain(SbSpectralDenoiser* self,
                                const float* delayed_fft,
                                const float* delayed_noise_bb,
-                               const float* delayed_noise_tonal, uint32_t slot,
+                               const float* delayed_noise_tonal,
+                               const float* delayed_tonal_mask, uint32_t slot,
                                float* gain_out, float* alpha, float* beta) {
   // Extract magnitude of the delayed frame (reuses the spectral features
   // buffer; the current-frame reference spectrum is no longer needed here)
@@ -1391,7 +1390,7 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
   masking_veto_apply(self->masking_veto, effective_magnitude, delayed_noise_bb,
                      NULL, alpha, self->parameters.masking_depth);
 #endif
-#if !(TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL)
+#if !TRANSIENT_RELIEF_PARALLEL
   // When transients are detected and enabled, drop alphas firmly to ALPHA_MIN
   // (1.0) strictly on the specific frequencies where transient energy was
   // detected. Band-level weight (see run_nlm_chain 3.4).
@@ -1435,7 +1434,7 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
                   delayed_noise_bb, gain_out, alpha, beta,
                   self->gain_calculation_type, self->knee_spectrum);
 
-#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+#if TRANSIENT_RELIEF_PARALLEL
   // Transient relief as a parallel GAIN-domain branch: blend the base gain
   // toward the plain Wiener curve (alpha = ALPHA_MIN, same knee) by the band
   // protection weight. Matches legacy at full/no protection; at partial
@@ -1477,7 +1476,10 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
       (TimeSmoothingParameters){
           .smoothing = fminf(self->parameters.smoothing_factor,
                              GAIN_SMOOTHING_RELEASE_P_CAP),
-          .transient_mask = self->transient_band_mask,
+          // Instant attack only on the detected frame; during the relief hold
+          // the smoother must keep owning the gain (no held-mask override).
+          .transient_mask =
+              self->is_transient_detected ? self->transient_band_mask : NULL,
           .release_scale = (self->parameters.smoothing_factor > 0.0F)
                                ? self->release_scale
                                : NULL, // Unused while bypassed
@@ -1498,7 +1500,7 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
 #if TONAL_DUAL_PATH
   tonal_reducer_compute_tonal_gains(
       self->tonal_reducer, slot, effective_magnitude, delayed_noise_tonal,
-      self->parameters.tonal_reduction, self->gain_tonal);
+      delayed_tonal_mask, self->parameters.tonal_reduction, self->gain_tonal);
   for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
     gain_out[k] = fminf(gain_out[k], self->gain_tonal[k]);
   }
@@ -1507,7 +1509,9 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
   // Transient Protection re-asserted after the combine: a band onset must
   // not be notched by a tonal bin underneath it (floor is now strictly >=
   // the legacy pre-smoothing behavior on transient x tonal overlap bins).
-  if (self->transient_protection_active) {
+  // Keyed to the detector's current frame (the UI LED state), not the 200 ms
+  // relief hold, so the smoothed gain wins again through the sustain.
+  if (self->is_transient_detected) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
       float t_weight = self->transient_mask[k];
       if (t_weight > 0.0F) {

--- a/src/processors/denoiser/spectral_denoiser.c
+++ b/src/processors/denoiser/spectral_denoiser.c
@@ -78,14 +78,23 @@ typedef struct SbSpectralDenoiser {
   float* noise_spectrum;            // Copy of noise profile for processing
   float* noise_spectrum_buffers[2]; // Double-buffered noise spectrum for
                                     // lock-free SPSC publication
+  float* noise_bb;                  // Broadband profile (tonal peaks lifted)
+  float* noise_tonal;               // Tonal residual (parallel gain path)
+  float* gain_tonal;                // Tonal gain path output (shared scratch)
   atomic_int
       active_noise_idx; // Index of current published noise spectrum (0 or 1)
   float* alpha;         // Oversubtraction factors (active chain)
   float* beta;          // Undersubtraction factors (active chain)
   float* alpha_b;       // Oversubtraction factors (transition chain)
-  float* alpha_base;    // Scratch: Berouti base for parallel combine (NLM)
-  float* alpha_tonal;   // Scratch: tonal branch result (NLM parallel)
-  float* beta_b;        // Undersubtraction factors (transition chain)
+#if !TONAL_DUAL_PATH
+  float* alpha_base;  // Legacy combined-path scratch (Berouti base)
+  float* alpha_tonal; // Legacy combined-path scratch (tonal branch)
+#endif
+  float* beta_b; // Undersubtraction factors (transition chain)
+#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+  float* alpha_relief; // Relief-branch alpha (all ALPHA_MIN)
+  float* gain_relief;  // Relief-branch preservation gain (parallel output)
+#endif
   float* manual_noise_floor; // Manual profile floor
   TonalReducer* tonal_reducer;
 
@@ -114,6 +123,10 @@ typedef struct SbSpectralDenoiser {
   CriticalBands* critical_bands;
   TransientDetector* transient_detector;
 
+  // Circular buffer layers aligned at the common delay (broadband + tonal
+  // profiles ride along so the parallel tonal path describes the same tile)
+  uint32_t layer_noise_bb;
+  uint32_t layer_noise_tonal;
   float* band_energies;
   float* onset_weights;
   float* held_weights;        // Band weights decayed after detection (hold)
@@ -180,14 +193,21 @@ static void align_bypass_frame(SbSpectralDenoiser* self, float* fft_spectrum,
   if (self->low_latency) {
     return; // causal: emit current frame, no delay
   }
+  // The bypass happens after the dual-path split, so the aligned layers stay
+  // in the same domain as the active chain (SNR fields must not mix domains
+  // across the idle→active boundary).
   spectral_circular_buffer_push(self->circular_buffer, self->layer_fft,
                                 fft_spectrum);
   spectral_circular_buffer_push(self->circular_buffer, self->layer_noise,
                                 self->noise_spectrum);
+  spectral_circular_buffer_push(self->circular_buffer, self->layer_noise_bb,
+                                self->noise_bb);
+  spectral_circular_buffer_push(self->circular_buffer, self->layer_noise_tonal,
+                                self->noise_tonal);
   spectral_circular_buffer_push(self->circular_buffer, self->layer_smoothed,
                                 reference_spectrum);
-  nlm_filter_calculate_snr(self->nlm_filter, reference_spectrum,
-                           self->noise_spectrum, self->snr_frame);
+  nlm_filter_calculate_snr(self->nlm_filter, reference_spectrum, self->noise_bb,
+                           self->snr_frame);
   nlm_filter_push_frame(self->nlm_filter, self->snr_frame);
   bm3d_filter_push_frame(self->bm3d_filter, self->snr_frame);
   const float* delayed_spectrum = spectral_circular_buffer_retrieve(
@@ -201,13 +221,15 @@ static void align_bypass_frame(SbSpectralDenoiser* self, float* fft_spectrum,
 
 static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
                           const float* smoothed_magnitude,
-                          const float* delayed_noise, float* gain_out,
-                          float* alpha, float* beta);
+                          const float* delayed_noise_bb,
+                          const float* delayed_noise_tonal, uint32_t slot,
+                          float* gain_out, float* alpha, float* beta);
 
 static void run_temporal_chain(SbSpectralDenoiser* self,
                                const float* delayed_fft,
-                               const float* delayed_noise, float* gain_out,
-                               float* alpha, float* beta);
+                               const float* delayed_noise_bb,
+                               const float* delayed_noise_tonal, uint32_t slot,
+                               float* gain_out, float* alpha, float* beta);
 
 static SpectralProcessorHandle spectral_denoiser_initialize_inner(
     const uint32_t sample_rate, const uint32_t fft_size,
@@ -254,13 +276,22 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
       (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->noise_spectrum_buffers[1] =
       (float*)calloc(self->real_spectrum_size, sizeof(float));
+  self->noise_bb = (float*)calloc(self->real_spectrum_size, sizeof(float));
+  self->noise_tonal = (float*)calloc(self->real_spectrum_size, sizeof(float));
+  self->gain_tonal = (float*)calloc(self->real_spectrum_size, sizeof(float));
   atomic_init(&self->active_noise_idx, 0);
   self->alpha = (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->beta = (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->alpha_b = (float*)calloc(self->real_spectrum_size, sizeof(float));
+  self->beta_b = (float*)calloc(self->real_spectrum_size, sizeof(float));
+#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+  self->alpha_relief = (float*)calloc(self->real_spectrum_size, sizeof(float));
+  self->gain_relief = (float*)calloc(self->fft_size, sizeof(float));
+#endif
+#if !TONAL_DUAL_PATH
   self->alpha_base = (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->alpha_tonal = (float*)calloc(self->real_spectrum_size, sizeof(float));
-  self->beta_b = (float*)calloc(self->real_spectrum_size, sizeof(float));
+#endif
   self->manual_noise_floor =
       (float*)calloc(self->real_spectrum_size, sizeof(float));
   self->smoothed_magnitude =
@@ -272,11 +303,17 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
   if (!self->snr_frame || !self->smoothed_snr || !self->dftt_snr ||
       !self->snr_delayed || !self->gain_spectrum || !self->gain_spectrum_b ||
       !self->noise_spectrum || !self->noise_spectrum_buffers[0] ||
-      !self->noise_spectrum_buffers[1] || !self->alpha || !self->beta ||
-      !self->alpha_b || !self->beta_b || !self->alpha_base ||
-      !self->alpha_tonal || !self->manual_noise_floor ||
-      !self->smoothed_magnitude || !self->clean_magnitude ||
-      !self->knee_spectrum) {
+      !self->noise_spectrum_buffers[1] || !self->noise_bb ||
+      !self->noise_tonal || !self->gain_tonal || !self->alpha || !self->beta ||
+      !self->alpha_b || !self->beta_b ||
+#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+      !self->alpha_relief || !self->gain_relief ||
+#endif
+#if !TONAL_DUAL_PATH
+      !self->alpha_base || !self->alpha_tonal ||
+#endif
+      !self->manual_noise_floor || !self->smoothed_magnitude ||
+      !self->clean_magnitude || !self->knee_spectrum) {
     spectral_denoiser_free(self);
     return NULL;
   }
@@ -289,6 +326,11 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
                                        1.F);
   (void)initialize_spectrum_with_value(self->alpha_b, self->real_spectrum_size,
                                        1.F);
+#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+  // Relief branch evaluates the plain Wiener curve (no oversubtraction)
+  (void)initialize_spectrum_with_value(self->alpha_relief,
+                                       self->real_spectrum_size, ALPHA_MIN);
+#endif
 
   // Initialize tonal reducer
   self->tonal_reducer = tonal_reducer_initialize(
@@ -311,9 +353,15 @@ static SpectralProcessorHandle spectral_denoiser_initialize_inner(
       self->circular_buffer, self->real_spectrum_size);
   self->layer_smoothed = spectral_circular_buffer_add_layer(
       self->circular_buffer, self->real_spectrum_size);
+  self->layer_noise_bb = spectral_circular_buffer_add_layer(
+      self->circular_buffer, self->real_spectrum_size);
+  self->layer_noise_tonal = spectral_circular_buffer_add_layer(
+      self->circular_buffer, self->real_spectrum_size);
 
   if (self->layer_fft == 0xFFFFFFFFU || self->layer_noise == 0xFFFFFFFFU ||
-      self->layer_smoothed == 0xFFFFFFFFU) {
+      self->layer_smoothed == 0xFFFFFFFFU ||
+      self->layer_noise_bb == 0xFFFFFFFFU ||
+      self->layer_noise_tonal == 0xFFFFFFFFU) {
     spectral_denoiser_free(self);
     return NULL;
   }
@@ -590,9 +638,18 @@ void spectral_denoiser_free(SpectralProcessorHandle instance) {
   free(self->alpha);
   free(self->beta);
   free(self->alpha_b);
+  free(self->beta_b);
+#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+  free(self->alpha_relief);
+  free(self->gain_relief);
+#endif
+#if !TONAL_DUAL_PATH
   free(self->alpha_base);
   free(self->alpha_tonal);
-  free(self->beta_b);
+#endif
+  free(self->noise_bb);
+  free(self->noise_tonal);
+  free(self->gain_tonal);
   if (self->manual_noise_floor) {
     free(self->manual_noise_floor);
   }
@@ -746,6 +803,26 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   };
   denoiser_profile_core_update(profile_params, reference_spectrum);
 
+  // 2.1 Dual-path tonal split: detect/publish the tonal mask and split the
+  // noise profile into a broadband floor (bb) and a tonal residual. The
+  // bb/tonal pair rides the circular buffer so the chains at the delayed
+  // frame consume a split aligned to their own tile; the raw profile (this
+  // frame's noise_spectrum) keeps feeding transient detection, the whitening
+  // floor and the published public profile unchanged.
+  // Legacy A/B build (TONAL_DUAL_PATH=0): identity split — the chains run on
+  // the raw profile and the tonal gain path stays a no-op; the whole coupled
+  // behavior lives in tonal_reducer_apply_alpha_boost below.
+#if TONAL_DUAL_PATH
+  const float split_reduction_gain = self->parameters.tonal_reduction;
+#else
+  const float split_reduction_gain = 1.0f;
+#endif
+  tonal_reducer_compute_split(
+      self->tonal_reducer, self->noise_spectrum,
+      get_noise_profile(self->noise_profile, CV_MASK),
+      is_noise_estimation_available(self->noise_profile, CV_MASK),
+      split_reduction_gain, self->noise_bb, self->noise_tonal);
+
   // Idle bypass: no manual profile and not adaptive → skip the heavy chain.
   // Preserve latency and buffer state: push current frame, output the frame
   // delayed by the common lookahead, and advance the circular buffer so
@@ -793,18 +870,24 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
   // (skipped in low-latency mode: causal, zero look-ahead)
   const float* delayed_spectrum = fft_spectrum;
   const float* delayed_noise = self->noise_spectrum;
+  const float* delayed_noise_bb = self->noise_bb;
+  const float* delayed_noise_tonal = self->noise_tonal;
   const float* nlm_smoothed = NULL;
   if (!self->low_latency) {
     spectral_circular_buffer_push(self->circular_buffer, self->layer_fft,
                                   fft_spectrum);
     spectral_circular_buffer_push(self->circular_buffer, self->layer_noise,
                                   self->noise_spectrum);
+    spectral_circular_buffer_push(self->circular_buffer, self->layer_noise_bb,
+                                  self->noise_bb);
+    spectral_circular_buffer_push(self->circular_buffer,
+                                  self->layer_noise_tonal, self->noise_tonal);
 
-    // Compute SNR for 2D filters using CURRENT noise and push frame. This
-    // keeps both NLM and BM3D histories rolling even in temporal mode so a
-    // runtime mode switch is seamless and allocation-free.
+    // Compute SNR for 2D filters using the broadband split (current frame)
+    // and push frame. This keeps both NLM and BM3D histories rolling even in
+    // temporal mode so a runtime mode switch is seamless and allocation-free.
     nlm_filter_calculate_snr(self->nlm_filter, reference_spectrum,
-                             self->noise_spectrum, self->snr_frame);
+                             self->noise_bb, self->snr_frame);
     nlm_filter_push_frame(self->nlm_filter, self->snr_frame);
     bm3d_filter_push_frame(self->bm3d_filter, self->snr_frame);
 
@@ -839,12 +922,22 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
         self->circular_buffer, self->layer_fft, nlm_delay);
     delayed_noise = spectral_circular_buffer_retrieve(
         self->circular_buffer, self->layer_noise, nlm_delay);
+    delayed_noise_bb = spectral_circular_buffer_retrieve(
+        self->circular_buffer, self->layer_noise_bb, nlm_delay);
+    delayed_noise_tonal = spectral_circular_buffer_retrieve(
+        self->circular_buffer, self->layer_noise_tonal, nlm_delay);
 
     if (!delayed_spectrum) {
       delayed_spectrum = fft_spectrum;
     }
     if (!delayed_noise) {
       delayed_noise = self->noise_spectrum;
+    }
+    if (!delayed_noise_bb) {
+      delayed_noise_bb = self->noise_bb;
+    }
+    if (!delayed_noise_tonal) {
+      delayed_noise_tonal = self->noise_tonal;
     }
 
     if (filter_ran) {
@@ -857,7 +950,7 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
           get_spectral_feature(self->spectral_features, delayed_spectrum,
                                self->fft_size, self->spectrum_type);
       nlm_filter_calculate_snr(self->nlm_filter, delayed_reference,
-                               delayed_noise, self->snr_delayed);
+                               delayed_noise_bb, self->snr_delayed);
       // DFTT post-filter (paper S4.2): the noisy SNR row aligned with the
       // 2D-emitted frame — recomputed from the delayed frames so both ring
       // inputs describe the same tile — is refined while the NLM output sets
@@ -897,7 +990,7 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
         }
       }
       nlm_filter_reconstruct_magnitude(self->nlm_filter, post_nlm,
-                                       delayed_noise, self->snr_frame);
+                                       delayed_noise_bb, self->snr_frame);
       spectral_circular_buffer_push(self->circular_buffer, self->layer_smoothed,
                                     self->snr_frame);
       nlm_smoothed = self->snr_frame;
@@ -1002,7 +1095,7 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
            self->real_spectrum_size * sizeof(float));
   }
 
-  // 3. Denoising Stage: dispatch the active smoothing strategy (or crossfade
+  // 3. Denoising Stage: dispatch the active smoothing strategy
   // both during a runtime mode transition; low-latency is always temporal)
   float* gain_a = self->gain_spectrum;
   float* gain_b = self->gain_spectrum_b;
@@ -1012,15 +1105,19 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
     const float w = (float)self->transition_pos / total; // 0 → 1
 
     if (is_2d_family(self->previous_mode)) {
-      (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise,
-                          gain_a, self->alpha, self->beta);
-      run_temporal_chain(self, fft_spectrum, delayed_noise, gain_b,
-                         self->alpha_b, self->beta_b);
+      (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise_bb,
+                          delayed_noise_tonal, 0U, gain_a, self->alpha,
+                          self->beta);
+      run_temporal_chain(self, fft_spectrum, delayed_noise_bb,
+                         delayed_noise_tonal, 1U, gain_b, self->alpha_b,
+                         self->beta_b);
     } else {
-      run_temporal_chain(self, fft_spectrum, delayed_noise, gain_a, self->alpha,
+      run_temporal_chain(self, fft_spectrum, delayed_noise_bb,
+                         delayed_noise_tonal, 0U, gain_a, self->alpha,
                          self->beta);
-      (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise,
-                          gain_b, self->alpha_b, self->beta_b);
+      (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise_bb,
+                          delayed_noise_tonal, 1U, gain_b, self->alpha_b,
+                          self->beta_b);
     }
 
     for (uint32_t k = 0U; k < self->fft_size; ++k) {
@@ -1033,10 +1130,12 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
       self->in_transition = false;
     }
   } else if (!self->low_latency && is_2d_family(self->active_mode)) {
-    (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise, gain_a,
-                        self->alpha, self->beta);
+    (void)run_nlm_chain(self, fft_spectrum, nlm_smoothed, delayed_noise_bb,
+                        delayed_noise_tonal, 0U, gain_a, self->alpha,
+                        self->beta);
   } else {
-    run_temporal_chain(self, fft_spectrum, delayed_noise, gain_a, self->alpha,
+    run_temporal_chain(self, fft_spectrum, delayed_noise_bb,
+                       delayed_noise_tonal, 0U, gain_a, self->alpha,
                        self->beta);
   }
 
@@ -1077,16 +1176,19 @@ bool spectral_denoiser_run(SpectralProcessorHandle instance,
 }
 
 /**
- * 2D Non-Local Means chain: NLM-smoothed magnitude feeds suppression, masking
- * veto, gain calculation. The smoothed magnitude produced by this frame's NLM
- * pass is passed in explicitly; when the NLM pass did not run or failed, the
- * last smoothed magnitude in the alignment buffer (or the delayed frame) is
- * used as an explicit fallback.
+ * 2D Non-Local Means chain: NLM-smoothed magnitude feeds broadband
+ * suppression (Berouti alpha + masking veto) and a Wiener evaluation against
+ * the BROADBAND noise profile only. The tonal residual is handled by the
+ * parallel tonal gain path; the final bin gain is
+ * min(broadband, tonal) with the transient floor re-asserted on top.
+ * When the tonal path is inactive (reduction >= ~1.0 or zero mask) the tonal
+ * gain is unity and the min() is a no-op.
  */
 static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
                           const float* smoothed_magnitude,
-                          const float* delayed_noise, float* gain_out,
-                          float* alpha, float* beta) {
+                          const float* delayed_noise_bb,
+                          const float* delayed_noise_tonal, uint32_t slot,
+                          float* gain_out, float* alpha, float* beta) {
   if (!smoothed_magnitude) {
     smoothed_magnitude = spectral_circular_buffer_retrieve(
         self->circular_buffer, self->layer_smoothed, 0U);
@@ -1095,29 +1197,31 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
     smoothed_magnitude = fft_spectrum;
   }
 
-  // 3.1 Calculate SNR-dependent oversubtraction factors (Alpha/Beta)
+  // Calculate SNR-dependent oversubtraction factors (Alpha/Beta) on the
+  // broadband profile: tonal noise no longer depresses the per-bin SNR here.
   SuppressionParameters suppression_params = {
       .type = SUPPRESSION_BEROUTI_PER_BIN,
       .strength = self->parameters.suppression_strength,
       .undersubtraction = 0.0F};
   suppression_engine_calculate(self->suppression_engine, smoothed_magnitude,
-                               delayed_noise, suppression_params, alpha, beta);
+                               delayed_noise_bb, suppression_params, alpha,
+                               beta);
 
-  // 3.2 + 3.3 Parallel branches from the same Berouti base: the tonal
-  // branch adds suppression where the noise profile is tonal, the veto
-  // branch lifts toward 1.0 where noise is psychoacoustically masked.
-  // Each branch modulates the base independently with its own per-bin
-  // weight (tonal mask strength / NMR protection), then the two deltas
-  // are combined once: alpha = base + boost - preservation. No blanket
-  // caps, no depth scaling, no post-hoc gain blur — each stage contributes
-  // exactly what its own confidence supports.
+#if TONAL_DUAL_PATH
+  // Structural Veto on the broadband profile: alpha lifts where noise is
+  // psychoacoustically masked. With the tonal notch decoupled into its own
+  // gain path, the veto can no longer partially undo a tonal boost
+  // (order-dependence removed).
+  masking_veto_apply(self->masking_veto, smoothed_magnitude, delayed_noise_bb,
+                     fft_spectrum, alpha, self->parameters.masking_depth);
+#else
+  // Legacy coupled path: parallel branches from the same Berouti base (the
+  // tonal branch boosts, the veto branch preserves), combined once.
   memcpy(self->alpha_base, alpha, self->real_spectrum_size * sizeof(float));
   memcpy(self->alpha_tonal, alpha, self->real_spectrum_size * sizeof(float));
-  tonal_reducer_run(self->tonal_reducer, delayed_noise,
-                    get_noise_profile(self->noise_profile, CV_MASK),
-                    is_noise_estimation_available(self->noise_profile, CV_MASK),
-                    self->alpha_tonal, self->parameters.tonal_reduction);
-  masking_veto_apply(self->masking_veto, smoothed_magnitude, delayed_noise,
+  tonal_reducer_apply_alpha_boost(self->tonal_reducer, self->alpha_tonal,
+                                  self->parameters.tonal_reduction);
+  masking_veto_apply(self->masking_veto, smoothed_magnitude, delayed_noise_bb,
                      fft_spectrum, alpha, self->parameters.masking_depth);
   for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
     const float boost = self->alpha_tonal[k] - self->alpha_base[k];
@@ -1126,13 +1230,10 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
     combined = fminf(combined, ALPHA_MAX_TONAL);
     alpha[k] = fmaxf(ALPHA_MIN, combined);
   }
+#endif
 
-  // 3.4. Transient Protection:
-  // Strictly on frequencies where transient was detected, drop alpha to
-  // ALPHA_MIN (1.0). Band-level weight: the Wiener curve itself keeps
-  // noise-dominant bins closed at alpha_min, while tonal transient
-  // components only modestly above the noise (excluded by the per-bin
-  // evidence gate) keep their oversubtraction relief.
+#if !(TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL)
+  // Transient Protection: alpha relief on detected band onsets.
   if (self->transient_protection_active) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
       float t_weight = self->transient_band_mask[k];
@@ -1144,12 +1245,45 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
       }
     }
   }
+#endif
 
-  // 3.5. Gain Calculation
+  // Broadband gain calculation: stationary tonal peaks are gone from the
+  // profile, so the 2D-smoothed Wiener gain is a smooth field.
   calculate_gains(self->real_spectrum_size, self->fft_size, smoothed_magnitude,
-                  delayed_noise, gain_out, alpha, beta,
+                  delayed_noise_bb, gain_out, alpha, beta,
                   self->gain_calculation_type, NULL);
 
+#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+  // Transient relief as a parallel GAIN-domain branch (see run_temporal_chain
+  // for rationale): blend the base gain toward the plain Wiener curve by the
+  // band protection weight.
+  if (self->transient_protection_active) {
+    calculate_gains(self->real_spectrum_size, self->fft_size,
+                    smoothed_magnitude, delayed_noise_bb, self->gain_relief,
+                    self->alpha_relief, beta, self->gain_calculation_type,
+                    NULL);
+    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+      const float pf = sqrtf(self->transient_band_mask[k]);
+      if (pf > 0.0F) {
+        gain_out[k] = ((1.0F - pf) * gain_out[k]) + (pf * self->gain_relief[k]);
+      }
+    }
+  }
+#endif
+
+#if TONAL_DUAL_PATH
+  // Parallel tonal gain path + decision criterion. Ran on the same
+  // smoothed magnitude so the min() compares like with like.
+  tonal_reducer_compute_tonal_gains(
+      self->tonal_reducer, slot, smoothed_magnitude, delayed_noise_tonal,
+      self->parameters.tonal_reduction, self->gain_tonal);
+  for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+    gain_out[k] = fminf(gain_out[k], self->gain_tonal[k]);
+  }
+#endif
+
+  // Transient Protection re-asserted after the combine: a band onset must
+  // not be notched by a tonal bin underneath it.
   if (self->transient_protection_active) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
       float t_weight = self->transient_mask[k];
@@ -1169,8 +1303,9 @@ static bool run_nlm_chain(SbSpectralDenoiser* self, float* fft_spectrum,
  */
 static void run_temporal_chain(SbSpectralDenoiser* self,
                                const float* delayed_fft,
-                               const float* delayed_noise, float* gain_out,
-                               float* alpha, float* beta) {
+                               const float* delayed_noise_bb,
+                               const float* delayed_noise_tonal, uint32_t slot,
+                               float* gain_out, float* alpha, float* beta) {
   // Extract magnitude of the delayed frame (reuses the spectral features
   // buffer; the current-frame reference spectrum is no longer needed here)
   float* delayed_magnitude =
@@ -1232,24 +1367,31 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
   spectral_circular_buffer_push(self->circular_buffer, self->layer_smoothed,
                                 self->smoothed_magnitude);
 
-  // Calculate SNR-dependent oversubtraction factors (Alpha/Beta)
+  // Calculate SNR-dependent oversubtraction factors (Alpha/Beta) on the
+  // broadband profile: tonal noise no longer depresses the per-bin SNR here.
   SuppressionParameters suppression_params = {
       .type = SUPPRESSION_BEROUTI_PER_BIN,
       .strength = self->parameters.suppression_strength,
       .undersubtraction = 0.0F};
   suppression_engine_calculate(self->suppression_engine, effective_magnitude,
-                               delayed_noise, suppression_params, alpha, beta);
-
-  // Detect tonal components and boost alpha at tonal bins
-  tonal_reducer_run(self->tonal_reducer, delayed_noise,
-                    get_noise_profile(self->noise_profile, CV_MASK),
-                    is_noise_estimation_available(self->noise_profile, CV_MASK),
-                    alpha, self->parameters.tonal_reduction);
-
-  // Apply Structural Veto to rescue psychoacoustically masked signal
-  masking_veto_apply(self->masking_veto, effective_magnitude, delayed_noise,
+                               delayed_noise_bb, suppression_params, alpha,
+                               beta);
+#if TONAL_DUAL_PATH
+  // Apply Structural Veto on the broadband profile. The tonal notch lives in
+  // its own parallel gain path, so the veto can no longer partially undo a
+  // tonal alpha boost (sequential order-dependence removed).
+  masking_veto_apply(self->masking_veto, effective_magnitude, delayed_noise_bb,
                      NULL, alpha, self->parameters.masking_depth);
-
+#else
+  // Legacy coupled path: tonal alpha boost applied inline BEFORE the veto,
+  // so the veto can partially undo the boost at masked bins (the coupled
+  // behavior under measurement).
+  tonal_reducer_apply_alpha_boost(self->tonal_reducer, alpha,
+                                  self->parameters.tonal_reduction);
+  masking_veto_apply(self->masking_veto, effective_magnitude, delayed_noise_bb,
+                     NULL, alpha, self->parameters.masking_depth);
+#endif
+#if !(TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL)
   // When transients are detected and enabled, drop alphas firmly to ALPHA_MIN
   // (1.0) strictly on the specific frequencies where transient energy was
   // detected. Band-level weight (see run_nlm_chain 3.4).
@@ -1264,6 +1406,7 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
       }
     }
   }
+#endif
 
   // Signal-dependent knee width: bins decaying from recent signal presence
   // (stabilized energy above the current raw hop) get a wider knee so weak
@@ -1272,9 +1415,9 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
   if (self->parameters.smoothing_factor > 0.0F) {
     for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
       float decay_evidence = 0.0F;
-      if (delayed_noise[k] > FLT_MIN) {
-        decay_evidence =
-            (effective_magnitude[k] - delayed_magnitude[k]) / delayed_noise[k];
+      if (delayed_noise_bb[k] > FLT_MIN) {
+        decay_evidence = (effective_magnitude[k] - delayed_magnitude[k]) /
+                         delayed_noise_bb[k];
       }
       self->knee_spectrum[k] =
           GAIN_WIENER_KNEE +
@@ -1285,10 +1428,32 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
     memset(self->knee_spectrum, 0, self->real_spectrum_size * sizeof(float));
   }
 
-  // Gain Calculation
+  // Gain Calculation on the broadband profile only: the temporal/spatial
+  // smoothers below therefore never see a stationary tonal notch carved into
+  // their gain field.
   calculate_gains(self->real_spectrum_size, self->fft_size, effective_magnitude,
-                  delayed_noise, gain_out, alpha, beta,
+                  delayed_noise_bb, gain_out, alpha, beta,
                   self->gain_calculation_type, self->knee_spectrum);
+
+#if TONAL_DUAL_PATH && TRANSIENT_RELIEF_PARALLEL
+  // Transient relief as a parallel GAIN-domain branch: blend the base gain
+  // toward the plain Wiener curve (alpha = ALPHA_MIN, same knee) by the band
+  // protection weight. Matches legacy at full/no protection; at partial
+  // band weights it is softer than the legacy alpha lerp because the Wiener
+  // curve is nonlinear in alpha, and the shared alpha is no longer mutated.
+  if (self->transient_protection_active) {
+    calculate_gains(self->real_spectrum_size, self->fft_size,
+                    effective_magnitude, delayed_noise_bb, self->gain_relief,
+                    self->alpha_relief, beta, self->gain_calculation_type,
+                    self->knee_spectrum);
+    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+      const float pf = sqrtf(self->transient_band_mask[k]);
+      if (pf > 0.0F) {
+        gain_out[k] = ((1.0F - pf) * gain_out[k]) + (pf * self->gain_relief[k]);
+      }
+    }
+  }
+#endif
 
   // Transient Protection: ensure transient bins have gain near 1.0
   if (self->transient_protection_active) {
@@ -1323,6 +1488,31 @@ static void run_temporal_chain(SbSpectralDenoiser* self,
     int passes = 1 + (int)(self->parameters.smoothing_factor * 2.0f);
     for (int p = 0; p < passes; ++p) {
       spectral_smoothing_apply_spatial(gain_out, self->real_spectrum_size);
+    }
+  }
+
+  // Parallel tonal gain path + decision criterion, applied AFTER the
+  // time/spatial smoothers: the notch enters the final gain at full depth
+  // without being smeared into neighbors by the spatial FIR, and the
+  // smoother state is never dragged around by mask flicker.
+#if TONAL_DUAL_PATH
+  tonal_reducer_compute_tonal_gains(
+      self->tonal_reducer, slot, effective_magnitude, delayed_noise_tonal,
+      self->parameters.tonal_reduction, self->gain_tonal);
+  for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+    gain_out[k] = fminf(gain_out[k], self->gain_tonal[k]);
+  }
+#endif
+
+  // Transient Protection re-asserted after the combine: a band onset must
+  // not be notched by a tonal bin underneath it (floor is now strictly >=
+  // the legacy pre-smoothing behavior on transient x tonal overlap bins).
+  if (self->transient_protection_active) {
+    for (uint32_t k = 0U; k < self->real_spectrum_size; ++k) {
+      float t_weight = self->transient_mask[k];
+      if (t_weight > 0.0F) {
+        gain_out[k] = fmaxf(gain_out[k], t_weight);
+      }
     }
   }
 }

--- a/src/shared/configurations.h
+++ b/src/shared/configurations.h
@@ -154,6 +154,49 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define TONAL_REDUCER_NEGLIGIBLE_NOISE_THRESHOLD (1e-12F)
 #define ALPHA_MAX_TONAL (10.F)
 
+// Tonal/broadband dual-path decoupling: the noise profile is split into a
+// broadband floor N_bb (tonal peaks replaced by a morphological-opening
+// envelope of the profile) and a tonal residual N_tonal = N - N_bb. All
+// broadband suppression and gain smoothing run on N_bb only, while a parallel
+// tonal gain path (second Wiener evaluation against N_tonal) supplies the
+// narrowband notch; the final per-bin gain is min(broadband, tonal). This
+// keeps the temporal/spatial smoothers' gain fields free of stationary tonal
+// notches (they no longer carve or smear into neighbors), and the notch keeps
+// its full depth in exchange.
+// Morphological opening window: peaks narrower than this window are treated
+// as tonal and lifted out of the broadband profile. Must comfortably cover
+// the spacing of the strongest hum/buzz harmonic series (50/60 Hz).
+#define TONAL_DETONE_WINDOW_HZ (150.0F)
+#define TONAL_DETONE_MIN_BINS (4U)
+#define TONAL_DETONE_MAX_BINS (16U)
+// Softening pass on the extracted envelope (dupe of smooth_spectrum factor).
+#define TONAL_DETONE_SMOOTHING (0.5F)
+// One-pole stabilization of the tonal gain path (mask flicker rejection),
+// frame-rate invariant (alpha = exp(-1/N) at any hop size).
+#define TONAL_GAIN_STABILIZATION_HOPS 3U
+
+// Measurement toggle (A/B test bed for the tonal decoupling): 1 = decoupled
+// dual-path (tonal notch as a parallel gain path, smoothers see a broadband
+// field only). 0 = legacy coupled path (tonal alpha boost applied inline to
+// the single gain chain that the smoothen follow tonal carving included).
+// Build the comparison variant with -DTONAL_DUAL_PATH=0.
+#ifndef TONAL_DUAL_PATH
+#define TONAL_DUAL_PATH 1
+#endif
+
+// Measurement toggle (A/B test bed for the transient relief rearrangement):
+// 1 = the band-level transient alpha relief (alpha lerped toward ALPHA_MIN
+// pre-gain) is instead applied as a parallel GAIN-domain blend after the
+// base gain evaluation: g' = (1-pf)*g_base + pf*Wiener(alpha=ALPHA_MIN,
+// same knee). Equal to legacy at full/no protection, differs at partial
+// band weights where the Wiener curve is nonlinear in alpha (gain-domain
+// relief is softer, never overshoots, and no longer mutates the shared
+// alpha). 0 = legacy alpha-domain relief.
+// Build the comparison variant with -DTRANSIENT_RELIEF_PARALLEL=0.
+#ifndef TRANSIENT_RELIEF_PARALLEL
+#define TRANSIENT_RELIEF_PARALLEL 1
+#endif
+
 // Transient Detector Constants
 #define UPPER_LIMIT (5.F)
 #define DEFAULT_TRANSIENT_THRESHOLD (2.F)

--- a/src/shared/denoiser_logic/processing/tonal_reducer.c
+++ b/src/shared/denoiser_logic/processing/tonal_reducer.c
@@ -1,14 +1,38 @@
 /*
 libspecbleach - A spectral processing library
+
+Copyright 2022 Luciano Dato <lucianodato@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "shared/denoiser_logic/processing/tonal_reducer.h"
 #include "shared/configurations.h"
+#include "shared/frame_rate_norm.h"
+#include "shared/utils/spectral_utils.h"
 #include "shared/utils/tonal_detector.h"
+#include <float.h>
 #include <math.h>
 #include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
+
+static void tonal_reducer_compute_mask(TonalReducer* self,
+                                       const float* noise_spectrum,
+                                       const float* cv_mask_profile,
+                                       bool cv_mask_available);
 
 struct TonalReducer {
   uint32_t real_spectrum_size;
@@ -18,7 +42,200 @@ struct TonalReducer {
   float* tonal_mask_buffers[2];
   uint32_t* deque_workspace;
   atomic_int active_mask_idx;
+
+  // Dual-path decoupling state
+  float* envelope;       // Opening(N): broadband baseline under the peaks
+  float* alpha_tonal;    // Per-bin alpha for the tonal Wiener evaluation
+  float* gain_memory[2]; // Tonal gain one-pole state per chain slot
+  bool gain_seeded[2];
 };
+
+static void publish_mask(TonalReducer* self) {
+  int published_idx =
+      atomic_load_explicit(&self->active_mask_idx, memory_order_relaxed);
+  int write_idx = 1 - published_idx;
+  memcpy(self->tonal_mask_buffers[write_idx], self->tonal_mask,
+         self->real_spectrum_size * sizeof(float));
+  atomic_store_explicit(&self->active_mask_idx, write_idx,
+                        memory_order_release);
+}
+
+void tonal_reducer_compute_mask(TonalReducer* self, const float* noise_spectrum,
+                                const float* cv_mask_profile,
+                                bool cv_mask_available) {
+  if (!self || !noise_spectrum) {
+    return;
+  }
+
+  if (cv_mask_available && cv_mask_profile) {
+    // Manual Profile: copy CV mask directly
+    memcpy(self->tonal_mask, cv_mask_profile,
+           self->real_spectrum_size * sizeof(float));
+  } else {
+    // Idle (no profile, noise ~0) is the common steady state before learn:
+    // detect_tonal_components does 1200x15 insertion sorts per frame and
+    // dominates CPU while producing an all-zero mask. Early-out when noise is
+    // negligible; adaptive case has non-zero noise and will not take this
+    // path.
+    float max_val = 0.0f;
+    for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
+      if (noise_spectrum[k] > max_val) {
+        max_val = noise_spectrum[k];
+      }
+      if (max_val > TONAL_REDUCER_NEGLIGIBLE_NOISE_THRESHOLD) {
+        break;
+      }
+    }
+    if (max_val <= TONAL_REDUCER_NEGLIGIBLE_NOISE_THRESHOLD) {
+      memset(self->tonal_mask, 0, self->real_spectrum_size * sizeof(float));
+    } else {
+      detect_tonal_components(noise_spectrum, noise_spectrum,
+                              self->real_spectrum_size, self->sample_rate,
+                              self->fft_size, self->tonal_mask,
+                              self->deque_workspace);
+    }
+  }
+
+  publish_mask(self);
+}
+
+void tonal_reducer_compute_split(TonalReducer* self,
+                                 const float* noise_spectrum,
+                                 const float* cv_mask_profile,
+                                 bool cv_mask_available,
+                                 float tonal_reduction_gain, float* noise_bb,
+                                 float* noise_tonal) {
+  if (!self || !noise_spectrum || !noise_bb || !noise_tonal) {
+    return;
+  }
+
+  // The mask is always computed/published: the noise floor manager's
+  // dual-path budget, the profile tonal offset and the peak reporter consume
+  // it regardless of the requested reduction depth.
+  tonal_reducer_compute_mask(self, noise_spectrum, cv_mask_profile,
+                             cv_mask_available);
+
+  // Inactive tonal path: identity split (bb = N, tonal = 0), so downstream
+  // min() combining is a no-op and behavior matches the legacy single path.
+  if (tonal_reduction_gain >= 0.999f) {
+    memcpy(noise_bb, noise_spectrum, self->real_spectrum_size * sizeof(float));
+    memset(noise_tonal, 0, self->real_spectrum_size * sizeof(float));
+    return;
+  }
+
+  // Extract the broadband baseline under the tonal peaks and blend it in
+  // gated by mask strength. Bins without tonal evidence keep the profile
+  // exactly, so a missed detection stays on the legacy (safe) path.
+  const float bin_hz = (self->fft_size > 0U)
+                           ? ((float)self->sample_rate / (float)self->fft_size)
+                           : 0.0F;
+  const uint32_t window =
+      sb_bins_for_hz(TONAL_DETONE_WINDOW_HZ, bin_hz, TONAL_DETONE_MIN_BINS,
+                     TONAL_DETONE_MAX_BINS);
+  if (!sb_spectral_envelope_opening(noise_spectrum, self->envelope, noise_bb,
+                                    self->real_spectrum_size, window)) {
+    // Envelope failure: keep the legacy profile everywhere
+    memcpy(noise_bb, noise_spectrum, self->real_spectrum_size * sizeof(float));
+    memset(noise_tonal, 0, self->real_spectrum_size * sizeof(float));
+    return;
+  }
+
+  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
+    const float w = fminf(self->tonal_mask[k], 1.0f);
+    if (w <= 0.0f) {
+      noise_bb[k] = noise_spectrum[k];
+    } else {
+      noise_bb[k] = (noise_spectrum[k] * (1.0f - w)) + (noise_bb[k] * w);
+    }
+    // Tonal residual handed to the parallel gain path (clamped >= 0)
+    noise_tonal[k] = fmaxf(noise_spectrum[k] - noise_bb[k], 0.0f);
+  }
+}
+
+void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
+                                       const float* smoothed_magnitude,
+                                       const float* noise_tonal,
+                                       float tonal_reduction_gain,
+                                       float* gain_tonal) {
+  if (!self || !smoothed_magnitude || !noise_tonal || !gain_tonal ||
+      slot >= 2U) {
+    return;
+  }
+
+  // Inactive tonal path (no residual anywhere): emit unity gains and keep the
+  // one-pole state unused so reactivation starts from the fresh gains.
+  bool any_tonal = false;
+  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
+    if (noise_tonal[k] > FLT_EPSILON) {
+      any_tonal = true;
+      break;
+    }
+  }
+  if (!any_tonal) {
+    initialize_spectrum_with_value(gain_tonal, self->real_spectrum_size, 1.0f);
+    self->gain_seeded[slot] = false;
+    return;
+  }
+
+  // Alpha mapping identical to the legacy tonal alpha boost: mask-weighted
+  // interpolation between ALPHA_MIN and the reduction-depth alpha.
+  const float tonal_reduction_strength = 1.0f - tonal_reduction_gain;
+  const float alpha_needed =
+      ALPHA_MIN + (tonal_reduction_strength * (ALPHA_MAX_TONAL - ALPHA_MIN));
+  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
+    const float mask = fminf(self->tonal_mask[k], 1.0f);
+    self->alpha_tonal[k] = ALPHA_MIN + (mask * (alpha_needed - ALPHA_MIN));
+  }
+
+  // Second Wiener evaluation on the tonal residual: plain subtraction curve
+  // (no knee, no symmetry — the output is a half-spectrum whose upper bins
+  // are ignored downstream). Notch is decisive at masked bins.
+  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
+    const float scaled_noise = noise_tonal[k] * self->alpha_tonal[k];
+    const float mag = smoothed_magnitude[k];
+    if (scaled_noise > FLT_MIN && mag > FLT_MIN) {
+      const float diff = mag - scaled_noise;
+      gain_tonal[k] = (diff > 0.0F) ? sqrtf(diff / mag) : 0.0F;
+    } else {
+      gain_tonal[k] = 1.0F;
+    }
+  }
+  // Light one-pole stabilization: the notch is applied after the gain
+  // smoothers, so mask flicker would otherwise enter the final gain raw.
+  // Stationary tonal noise makes the small lag harmless. First-ever frame
+  // per slot seeds the state with the raw gains (no ramp-in).
+  const float alpha = expf(-1.0F / (float)TONAL_GAIN_STABILIZATION_HOPS);
+  if (!self->gain_seeded[slot]) {
+    memcpy(self->gain_memory[slot], gain_tonal,
+           self->real_spectrum_size * sizeof(float));
+    self->gain_seeded[slot] = true;
+    return;
+  }
+  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
+    gain_tonal[k] =
+        (alpha * self->gain_memory[slot][k]) + ((1.0F - alpha) * gain_tonal[k]);
+    self->gain_memory[slot][k] = gain_tonal[k];
+  }
+}
+
+void tonal_reducer_apply_alpha_boost(TonalReducer* self, float* alpha,
+                                     float tonal_reduction_gain) {
+  if (!self || !alpha || tonal_reduction_gain >= 0.999f) {
+    return;
+  }
+
+  const float tonal_reduction_strength = 1.0f - tonal_reduction_gain;
+  const float alpha_needed =
+      ALPHA_MIN + (tonal_reduction_strength * (ALPHA_MAX_TONAL - ALPHA_MIN));
+  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
+    if (self->tonal_mask[k] <= 0.0f) {
+      continue;
+    }
+    const float target_alpha = ALPHA_MIN + (fminf(self->tonal_mask[k], 1.0f) *
+                                            (alpha_needed - ALPHA_MIN));
+    alpha[k] = fmaxf(alpha[k], target_alpha);
+  }
+}
 
 TonalReducer* tonal_reducer_initialize(uint32_t real_spectrum_size,
                                        uint32_t sample_rate,
@@ -54,6 +271,16 @@ TonalReducer* tonal_reducer_initialize(uint32_t real_spectrum_size,
     return NULL;
   }
 
+  self->envelope = (float*)calloc(real_spectrum_size, sizeof(float));
+  self->alpha_tonal = (float*)calloc(real_spectrum_size, sizeof(float));
+  self->gain_memory[0] = (float*)calloc(real_spectrum_size, sizeof(float));
+  self->gain_memory[1] = (float*)calloc(real_spectrum_size, sizeof(float));
+  if (!self->envelope || !self->alpha_tonal || !self->gain_memory[0] ||
+      !self->gain_memory[1]) {
+    tonal_reducer_free(self);
+    return NULL;
+  }
+
   atomic_init(&self->active_mask_idx, 0);
 
   return self;
@@ -67,6 +294,10 @@ void tonal_reducer_free(TonalReducer* self) {
   free(self->tonal_mask_buffers[0]);
   free(self->tonal_mask_buffers[1]);
   free(self->tonal_mask);
+  free(self->envelope);
+  free(self->alpha_tonal);
+  free(self->gain_memory[0]);
+  free(self->gain_memory[1]);
   free(self);
 }
 
@@ -85,91 +316,15 @@ void tonal_reducer_reset(TonalReducer* self) {
     memset(self->tonal_mask_buffers[1], 0,
            self->real_spectrum_size * sizeof(float));
   }
+  if (self->gain_memory[0]) {
+    memset(self->gain_memory[0], 0, self->real_spectrum_size * sizeof(float));
+  }
+  if (self->gain_memory[1]) {
+    memset(self->gain_memory[1], 0, self->real_spectrum_size * sizeof(float));
+  }
+  self->gain_seeded[0] = false;
+  self->gain_seeded[1] = false;
   atomic_store_explicit(&self->active_mask_idx, 0, memory_order_release);
-}
-
-void tonal_reducer_run(TonalReducer* self, const float* noise_spectrum,
-                       const float* cv_mask_profile, bool cv_mask_available,
-                       float* alpha, float tonal_reduction_gain) {
-  if (!self || !noise_spectrum || !alpha) {
-    return;
-  }
-
-  if (cv_mask_available && cv_mask_profile) {
-    // Manual Profile: copy CV mask directly
-    memcpy(self->tonal_mask, cv_mask_profile,
-           self->real_spectrum_size * sizeof(float));
-
-    int published_idx =
-        atomic_load_explicit(&self->active_mask_idx, memory_order_relaxed);
-    int write_idx = 1 - published_idx;
-    memcpy(self->tonal_mask_buffers[write_idx], self->tonal_mask,
-           self->real_spectrum_size * sizeof(float));
-    atomic_store_explicit(&self->active_mask_idx, write_idx,
-                          memory_order_release);
-  } else {
-    // Idle (no profile, noise ~0) is the common steady state before learn:
-    // detect_tonal_components does 1200×15 insertion sorts per frame and
-    // dominates CPU while producing an all-zero mask. Early-out when noise is
-    // negligible; adaptive case has non-zero noise and will not take this path.
-    float max_val = 0.0f;
-    for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
-      if (noise_spectrum[k] > max_val) {
-        max_val = noise_spectrum[k];
-      }
-      if (max_val > TONAL_REDUCER_NEGLIGIBLE_NOISE_THRESHOLD) {
-        break;
-      }
-    }
-    if (max_val <= TONAL_REDUCER_NEGLIGIBLE_NOISE_THRESHOLD) {
-      memset(self->tonal_mask, 0, self->real_spectrum_size * sizeof(float));
-      int published_idx =
-          atomic_load_explicit(&self->active_mask_idx, memory_order_relaxed);
-      int write_idx = 1 - published_idx;
-      memcpy(self->tonal_mask_buffers[write_idx], self->tonal_mask,
-             self->real_spectrum_size * sizeof(float));
-      atomic_store_explicit(&self->active_mask_idx, write_idx,
-                            memory_order_release);
-    } else {
-      detect_tonal_components(noise_spectrum, noise_spectrum,
-                              self->real_spectrum_size, self->sample_rate,
-                              self->fft_size, self->tonal_mask,
-                              self->deque_workspace);
-      int published_idx =
-          atomic_load_explicit(&self->active_mask_idx, memory_order_relaxed);
-      int write_idx = 1 - published_idx;
-      memcpy(self->tonal_mask_buffers[write_idx], self->tonal_mask,
-             self->real_spectrum_size * sizeof(float));
-      atomic_store_explicit(&self->active_mask_idx, write_idx,
-                            memory_order_release);
-    }
-  }
-
-  // 2. Skip alpha boosting if reduction is 0 (no tonal suppression)
-  // Gain of 1.0 means no reduction.
-  if (tonal_reduction_gain >= 0.999f) {
-    return;
-  }
-
-  // 3. Boost alpha at tonal bins
-  //    Internally we work with strength (0..1) where 1 is max reduction.
-  float tonal_reduction_strength = 1.0f - tonal_reduction_gain;
-  float alpha_needed =
-      ALPHA_MIN + (tonal_reduction_strength * (ALPHA_MAX_TONAL - ALPHA_MIN));
-
-  for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
-    if (self->tonal_mask[k] <= 0.0f) {
-      continue;
-    }
-
-    // Weight by mask strength (partial tonal bins get proportional boost
-    // between ALPHA_MIN and alpha_needed)
-    float target_alpha =
-        ALPHA_MIN + (self->tonal_mask[k] * (alpha_needed - ALPHA_MIN));
-
-    // Only boost, never reduce (preserve existing suppression intent)
-    alpha[k] = fmaxf(alpha[k], target_alpha);
-  }
 }
 
 const float* tonal_reducer_get_mask(const TonalReducer* self) {

--- a/src/shared/denoiser_logic/processing/tonal_reducer.c
+++ b/src/shared/denoiser_logic/processing/tonal_reducer.c
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "shared/denoiser_logic/processing/tonal_reducer.h"
 #include "shared/configurations.h"
 #include "shared/frame_rate_norm.h"
+#include "shared/utils/simd_utils.h"
 #include "shared/utils/spectral_utils.h"
 #include "shared/utils/tonal_detector.h"
 #include <float.h>
@@ -155,11 +156,23 @@ void tonal_reducer_compute_split(TonalReducer* self,
 void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
                                        const float* smoothed_magnitude,
                                        const float* noise_tonal,
+                                       const float* tonal_mask,
                                        float tonal_reduction_gain,
                                        float* gain_tonal) {
   if (!self || !smoothed_magnitude || !noise_tonal || !gain_tonal ||
       slot >= 2U) {
     return;
+  }
+
+  // Per-bin sqrt/division on residual bins can decay into denormals; guard the
+  // whole pass like the other per-frame DSP paths.
+  sb_simd_state_t old_simd_state = sb_simd_enable_ftz_daz();
+
+  // The mask must describe the same (possibly delayed) tile as noise_tonal.
+  // Callers with a delayed residual pass the frame-aligned mask; a NULL mask
+  // falls back to the current one for causal/low-latency callers.
+  if (!tonal_mask) {
+    tonal_mask = self->tonal_mask;
   }
 
   // Inactive tonal path (no residual anywhere): emit unity gains and keep the
@@ -174,6 +187,7 @@ void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
   if (!any_tonal) {
     initialize_spectrum_with_value(gain_tonal, self->real_spectrum_size, 1.0f);
     self->gain_seeded[slot] = false;
+    sb_simd_restore_state(old_simd_state);
     return;
   }
 
@@ -183,7 +197,7 @@ void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
   const float alpha_needed =
       ALPHA_MIN + (tonal_reduction_strength * (ALPHA_MAX_TONAL - ALPHA_MIN));
   for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
-    const float mask = fminf(self->tonal_mask[k], 1.0f);
+    const float mask = fminf(tonal_mask[k], 1.0f);
     self->alpha_tonal[k] = ALPHA_MIN + (mask * (alpha_needed - ALPHA_MIN));
   }
 
@@ -209,6 +223,7 @@ void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
     memcpy(self->gain_memory[slot], gain_tonal,
            self->real_spectrum_size * sizeof(float));
     self->gain_seeded[slot] = true;
+    sb_simd_restore_state(old_simd_state);
     return;
   }
   for (uint32_t k = 0U; k < self->real_spectrum_size; k++) {
@@ -216,6 +231,29 @@ void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
         (alpha * self->gain_memory[slot][k]) + ((1.0F - alpha) * gain_tonal[k]);
     self->gain_memory[slot][k] = gain_tonal[k];
   }
+
+  sb_simd_restore_state(old_simd_state);
+}
+
+void tonal_reducer_promote_gain_slot(TonalReducer* self) {
+  if (!self || !self->gain_memory[0] || !self->gain_memory[1]) {
+    return;
+  }
+  memcpy(self->gain_memory[0], self->gain_memory[1],
+         self->real_spectrum_size * sizeof(float));
+  self->gain_seeded[0] = self->gain_seeded[1];
+}
+
+void tonal_reducer_swap_gain_slots(TonalReducer* self) {
+  if (!self) {
+    return;
+  }
+  float* gain_memory_tmp = self->gain_memory[0];
+  self->gain_memory[0] = self->gain_memory[1];
+  self->gain_memory[1] = gain_memory_tmp;
+  const bool seeded_tmp = self->gain_seeded[0];
+  self->gain_seeded[0] = self->gain_seeded[1];
+  self->gain_seeded[1] = seeded_tmp;
 }
 
 void tonal_reducer_apply_alpha_boost(TonalReducer* self, float* alpha,

--- a/src/shared/denoiser_logic/processing/tonal_reducer.h
+++ b/src/shared/denoiser_logic/processing/tonal_reducer.h
@@ -69,14 +69,30 @@ void tonal_reducer_compute_split(TonalReducer* self,
  *                            1 = transition/chain B)
  * @param smoothed_magnitude  Smoothed signal magnitude of the calling chain
  * @param noise_tonal         Tonal noise residual from compute_split
+ * @param tonal_mask          Mask aligned to the same delayed frame as
+ *                            noise_tonal (NULL falls back to the current mask)
  * @param tonal_reduction_gain Linear reduction coefficient (0.0–1.0)
  * @param gain_tonal          Output tonal gain spectrum (1.0 where no notch)
  */
 void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
                                        const float* smoothed_magnitude,
                                        const float* noise_tonal,
+                                       const float* tonal_mask,
                                        float tonal_reduction_gain,
                                        float* gain_tonal);
+
+/**
+ * Promote the transition (incoming) one-pole gain state in slot 1 into the
+ * active slot 0. Called when a crossfade completes so the newly-active chain
+ * continues from the state it built up while fading in.
+ */
+void tonal_reducer_promote_gain_slot(TonalReducer* self);
+
+/**
+ * Swap the two per-chain one-pole gain states. Called when an in-progress
+ * crossfade reverses so each chain keeps following its own history.
+ */
+void tonal_reducer_swap_gain_slots(TonalReducer* self);
 
 /**
  * Legacy (coupled-path) alpha boost: raise alpha toward the reduction-depth

--- a/src/shared/denoiser_logic/processing/tonal_reducer.h
+++ b/src/shared/denoiser_logic/processing/tonal_reducer.h
@@ -13,8 +13,8 @@ typedef struct TonalReducer TonalReducer;
 /**
  * Initialize the tonal reducer.
  *
- * Encapsulates tonal detection and alpha boosting. Must run BEFORE the
- * masking veto so the veto can naturally protect signal harmonics.
+ * Encapsulates tonal detection and the dual-path profile split (broadband vs
+ * tonal residual) plus the parallel tonal gain path.
  *
  * @param real_spectrum_size Number of spectral bins (fft_size/2 + 1)
  * @param sample_rate Audio sample rate in Hz
@@ -27,22 +27,65 @@ void tonal_reducer_free(TonalReducer* self);
 void tonal_reducer_reset(TonalReducer* self);
 
 /**
- * Detect tonal components and boost alpha at tonal bins.
+ * Split the noise profile into a broadband and a tonal part (dual-path
+ * decoupling). Also detects/publishes the tonal mask exactly as the old
+ * tonal_reducer_run did (used downstream by the noise floor manager's
+ * dual-path budget, the profile tonal offset and the peak reporter).
  *
- * Internally calls the tonal detector on the noise spectrum, then boosts
- * alpha proportionally so the Wiener filter suppresses tonal noise by
- * the requested dB amount.
+ * Broadband output `noise_bb`: at mask bins the profile is replaced by the
+ * morphological-opening envelope of the profile (tonal peaks lifted out),
+ * blended by mask strength; everywhere else it is a copy of the input.
+ * Tonal output `noise_tonal`: the extracted peak residual (N - N_bb).
  *
- * @param self             TonalReducer instance
- * @param noise_spectrum   Current noise estimate (morphed profile)
- * @param cv_mask_profile      Coefficient of Variation mask profile
- * @param cv_mask_available    Whether the CV mask profile is available
- * @param alpha                Per-bin oversubtraction array (modified in place)
+ * When the tonal path is inactive (tonal_reduction_gain >= ~1.0 or an all
+ * zero mask / negligible noise) both outputs degrade safely: `noise_bb`
+ * equals the input profile and `noise_tonal` is all zeros, so downstream
+ * min() combining is a no-op and behavior matches the legacy single path.
+ *
+ * @param self               TonalReducer instance
+ * @param noise_spectrum     Current noise estimate (morphed profile)
+ * @param cv_mask_profile    Coefficient of Variation mask profile
+ * @param cv_mask_available  Whether the CV mask profile is available
  * @param tonal_reduction_gain Linear reduction coefficient (0.0–1.0)
+ * @param noise_bb           Output broadband noise profile
+ * @param noise_tonal        Output tonal noise residual
  */
-void tonal_reducer_run(TonalReducer* self, const float* noise_spectrum,
-                       const float* cv_mask_profile, bool cv_mask_available,
-                       float* alpha, float tonal_reduction_gain);
+void tonal_reducer_compute_split(TonalReducer* self,
+                                 const float* noise_spectrum,
+                                 const float* cv_mask_profile,
+                                 bool cv_mask_available,
+                                 float tonal_reduction_gain, float* noise_bb,
+                                 float* noise_tonal);
+
+/**
+ * Compute the parallel tonal gain path: a second Wiener evaluation of the
+ * chain's (already smoothed) signal magnitude against the tonal residual.
+ * Depth follows the same mask-weighted alpha mapping the legacy alpha boost
+ * used (up to ALPHA_MAX_TONAL), so signal harmonics coinciding with hum bins
+ * survive when they exceed the tonal noise. Output is stabilized with a
+ * light per-bin one-pole state (TONAL_GAIN_STABILIZATION_HOPS).
+ *
+ * @param slot                Per-chain state slot (0 = active/chain A,
+ *                            1 = transition/chain B)
+ * @param smoothed_magnitude  Smoothed signal magnitude of the calling chain
+ * @param noise_tonal         Tonal noise residual from compute_split
+ * @param tonal_reduction_gain Linear reduction coefficient (0.0–1.0)
+ * @param gain_tonal          Output tonal gain spectrum (1.0 where no notch)
+ */
+void tonal_reducer_compute_tonal_gains(TonalReducer* self, uint32_t slot,
+                                       const float* smoothed_magnitude,
+                                       const float* noise_tonal,
+                                       float tonal_reduction_gain,
+                                       float* gain_tonal);
+
+/**
+ * Legacy (coupled-path) alpha boost: raise alpha toward the reduction-depth
+ * alpha at published tonal mask bins, only ever boosting (never reducing).
+ * Used by the build with TONAL_DUAL_PATH=0 to reproduce the pre-decoupling
+ * behavior for the A/B measurement; not part of the default path.
+ */
+void tonal_reducer_apply_alpha_boost(TonalReducer* self, float* alpha,
+                                     float tonal_reduction_gain);
 
 /**
  * Get the tonal mask from the last run (for downstream use like

--- a/src/shared/utils/spectral_utils.c
+++ b/src/shared/utils/spectral_utils.c
@@ -329,6 +329,49 @@ void interpolate_spectrum_gaps(float* spectrum, uint32_t size,
   }
 }
 
+// Sliding window extreme (min with is_min=true, max otherwise) over a
+// trailing window of `window` elements, clamped at the array edge. O(N*W)
+// with W <= TONAL_DETONE_MAX_BINS (16): a few thousand comparisons per frame
+// — negligible against the STFT/NLM cost, and immune to deque edge cases.
+static void sb_slide_extreme(const float* src, float* dst, uint32_t size,
+                             uint32_t window, const bool is_min) {
+  for (uint32_t i = 0U; i < size; i++) {
+    const uint32_t lo = (window > (i + 1U)) ? 0U : (i + 1U - window);
+    float ext = src[lo];
+    for (uint32_t j = lo + 1U; j <= i; j++) {
+      if (is_min) {
+        if (src[j] < ext) {
+          ext = src[j];
+        }
+      } else {
+        if (src[j] > ext) {
+          ext = src[j];
+        }
+      }
+    }
+    dst[i] = ext;
+  }
+}
+
+bool sb_spectral_envelope_opening(const float* spectrum, float* scratch,
+                                  float* out, const uint32_t size,
+                                  const uint32_t window) {
+  if (!spectrum || !scratch || !out || size == 0U || window == 0U) {
+    return false;
+  }
+  if (window > TONAL_DETONE_MAX_BINS) {
+    return false;
+  }
+
+  // Morphological opening: erosion (running min) then dilation (running max)
+  // removes narrowband peaks while preserving the broadband baseline level.
+  sb_slide_extreme(spectrum, scratch, size, window, true);
+  sb_slide_extreme(scratch, out, size, window, false);
+  smooth_spectrum(out, size, TONAL_DETONE_SMOOTHING);
+
+  return true;
+}
+
 bool get_morphed_profile(float* output_profile, const float* mean_profile,
                          const float* median_profile, const float* max_profile,
                          const float* min_profile, uint32_t size,

--- a/src/shared/utils/spectral_utils.c
+++ b/src/shared/utils/spectral_utils.c
@@ -329,16 +329,26 @@ void interpolate_spectrum_gaps(float* spectrum, uint32_t size,
   }
 }
 
-// Sliding window extreme (min with is_min=true, max otherwise) over a
-// trailing window of `window` elements, clamped at the array edge. O(N*W)
-// with W <= TONAL_DETONE_MAX_BINS (16): a few thousand comparisons per frame
-// — negligible against the STFT/NLM cost, and immune to deque edge cases.
+// Sliding window extreme (min with is_min=true, max otherwise). `forward`
+// selects the leading window [i, i+window-1]; otherwise the window trails
+// [i-window+1, i]. Both clamp at the array edges. O(N*W) with W <=
+// TONAL_DETONE_MAX_BINS (16): a few thousand comparisons per frame — negligible
+// against the STFT/NLM cost, and immune to deque edge cases.
 static void sb_slide_extreme(const float* src, float* dst, uint32_t size,
-                             uint32_t window, const bool is_min) {
+                             uint32_t window, const bool is_min,
+                             const bool forward) {
   for (uint32_t i = 0U; i < size; i++) {
-    const uint32_t lo = (window > (i + 1U)) ? 0U : (i + 1U - window);
+    uint32_t lo;
+    uint32_t hi;
+    if (forward) {
+      lo = i;
+      hi = (i + window > size) ? (size - 1U) : (i + window - 1U);
+    } else {
+      lo = (window > (i + 1U)) ? 0U : (i + 1U - window);
+      hi = i;
+    }
     float ext = src[lo];
-    for (uint32_t j = lo + 1U; j <= i; j++) {
+    for (uint32_t j = lo + 1U; j <= hi; j++) {
       if (is_min) {
         if (src[j] < ext) {
           ext = src[j];
@@ -363,10 +373,13 @@ bool sb_spectral_envelope_opening(const float* spectrum, float* scratch,
     return false;
   }
 
-  // Morphological opening: erosion (running min) then dilation (running max)
-  // removes narrowband peaks while preserving the broadband baseline level.
-  sb_slide_extreme(spectrum, scratch, size, window, true);
-  sb_slide_extreme(scratch, out, size, window, false);
+  // Morphological opening with opposed orientations: a trailing erosion
+  // followed by a leading dilation removes narrowband peaks while leaving
+  // monotonic baselines and steps where they are. Using the same orientation
+  // for both passes would delay the envelope by a full window, misaligning the
+  // extracted baseline from the tonal residual it is subtracted from.
+  sb_slide_extreme(spectrum, scratch, size, window, true, false);
+  sb_slide_extreme(scratch, out, size, window, false, true);
   smooth_spectrum(out, size, TONAL_DETONE_SMOOTHING);
 
   return true;

--- a/src/shared/utils/spectral_utils.h
+++ b/src/shared/utils/spectral_utils.h
@@ -71,6 +71,15 @@ bool get_morphed_profile(float* output_profile, const float* mean_profile,
                          const float* median_profile, const float* max_profile,
                          const float* min_profile, uint32_t size,
                          float aggressiveness);
+/**
+ * @brief Extracts a broadband baseline envelope from a noise profile via
+ * morphological opening (erosion + dilation with a flat window, then a light
+ * smoothing pass). Narrowband tonal peaks are removed while the surrounding
+ * broadband level is preserved. O(N), no allocation; needs `scratch` of
+ * `size` floats. `window` must be <= TONAL_DETONE_MAX_BINS.
+ */
+bool sb_spectral_envelope_opening(const float* spectrum, float* scratch,
+                                  float* out, uint32_t size, uint32_t window);
 
 #include "shared/utils/general_utils.h"
 

--- a/tests/test_audio_regression.c
+++ b/tests/test_audio_regression.c
@@ -1066,9 +1066,12 @@ void test_transient_pluck_preservation(void) {
   TEST_ASSERT(att_on > 0.9 * att_off, "Protection must not eat pluck attack");
   TEST_ASSERT(early_on > 0.9 * early_off, "Protection must not eat pluck body");
   /* Tail hold: the held band mask must keep oversubtraction relief alive
-   * into the decay tail (measured +3.7% tail energy on/off). */
+   * into the decay tail (measured +3.7% tail energy on/off), but bounded so
+   * the hold cannot inject audible broadband pumping (level lift). */
   TEST_ASSERT(late_on > late_off,
               "Protection hold must relieve the decay tail");
+  TEST_ASSERT(late_on < 1.10 * late_off,
+              "Protection hold must not pump the decay tail");
 
   free(input);
   free(out_on);

--- a/tests/test_integration_realworld_quality.c
+++ b/tests/test_integration_realworld_quality.c
@@ -1150,12 +1150,13 @@ static Metrics run_case_mode(const Signals* signals, uint32_t sample_rate,
   TEST_ASSERT(att_frames >= MIN_METRIC_FRAMES, "enough noise-only frames");
   m.att_db = (float)(10.0 * log10(mix_e / out_e));
   m.att_all_db = (float)(10.0 * log10(mix_e_all / out_e_all));
-  m.tonal_att_db = (tonal_out_e > 0.0)
-                       ? (float)(10.0 * log10(tonal_mix_e / tonal_out_e))
-                       : 0.0F;
-  m.halo_att_db = (halo_out_e > 0.0)
-                      ? (float)(10.0 * log10(halo_mix_e / halo_out_e))
-                      : 0.0F;
+  // Positive energy floor on both operands so complete suppression reports a
+  // finite positive attenuation instead of 0.0 dB (log10(0) is -inf).
+  const double att_energy_floor = 1e-12;
+  m.tonal_att_db = (float)(10.0 * log10((tonal_mix_e + att_energy_floor) /
+                                        (tonal_out_e + att_energy_floor)));
+  m.halo_att_db = (float)(10.0 * log10((halo_mix_e + att_energy_floor) /
+                                       (halo_out_e + att_energy_floor)));
   free(noise_psd);
   free(noise_bins);
 

--- a/tests/test_integration_realworld_quality.c
+++ b/tests/test_integration_realworld_quality.c
@@ -179,6 +179,12 @@ typedef struct Metrics {
   float decay_db;   // mean post-transient decay deficit
   float sisdr_db;   // SI-SDR of output vs clean (higher = cleaner)
   float sar_db;     // signal-to-artifacts ratio vs span{clean,noise}
+  // Tonal regional A/B (report-only): attenuation (dB) over noise-only
+  // frames in (1) the LEARNED noise's dominant tonal peak bins and (2) the
+  // bins flanking it. The decoupled tonal path should hold or deepen (1)
+  // without deepening (2) relative to the legacy coupled build.
+  float tonal_att_db;
+  float halo_att_db;
 } Metrics;
 
 typedef struct Signals {
@@ -370,7 +376,8 @@ static SpecbleachDenoiserParameters make_parameters(float smoothing,
       .tonal_reduction_gain = reduction_gain,
       .dftt_strength =
           mode == 2U ? 1.0F + reduction_db / DFTT_STRENGTH_DOUBLING_DB : 1.0F,
-      .transient_protection_enable = false};
+      .transient_protection_enable =
+          (getenv("SPECBLEACH_REALWORLD_TRANSIENT") != NULL)};
 }
 
 // Measures the true stream delay empirically: noise burst on a scratch
@@ -1045,8 +1052,8 @@ static Metrics run_case_mode(const Signals* signals, uint32_t sample_rate,
   remove_boundary_frames(active, noise_only, num_frames);
   remove_boundary_frames(noise_only, active, num_frames);
 
-  Metrics m = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
-               0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+  Metrics m = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
+               0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
 
   // Learned-noise bin selection: per-bin PSD from lead-in mix frames (the
   // same region the engine learned from). Energy-ratio attenuation over all
@@ -1094,11 +1101,28 @@ static Metrics run_case_mode(const Signals* signals, uint32_t sample_rate,
   }
   TEST_ASSERT(noise_bin_count >= MIN_NOISE_BINS, "learned noise bins found");
 
+  // Tonal regional breakdown: the dominant learned-noise peak bin and its
+  // flanks. Report-only A/B for the tonal decoupling measurement builds.
+  uint32_t peak_bin = 1U;
+  for (uint32_t k = 1U; k < bins; k++) {
+    if (noise_psd[k] > noise_psd[peak_bin]) {
+      peak_bin = k;
+    }
+  }
+  const uint32_t tonal_lo = (peak_bin > 1U) ? peak_bin - 1U : 1U;
+  const uint32_t tonal_hi = (peak_bin + 2U < bins) ? peak_bin + 2U : bins - 1U;
+  const uint32_t halo_lo = (peak_bin > 6U) ? peak_bin - 6U : 1U;
+  const uint32_t halo_hi = (peak_bin + 7U < bins) ? peak_bin + 7U : bins - 1U;
+
   // Att: attenuation over noise-only frames
   double mix_e = 0.0;
   double out_e = 0.0;
   double mix_e_all = 0.0;
   double out_e_all = 0.0;
+  double tonal_mix_e = 0.0;
+  double tonal_out_e = 0.0;
+  double halo_mix_e = 0.0;
+  double halo_out_e = 0.0;
   uint32_t att_frames = 0U;
   for (uint32_t f = 0U; f < num_frames; f++) {
     if (!noise_only[f]) {
@@ -1106,17 +1130,32 @@ static Metrics run_case_mode(const Signals* signals, uint32_t sample_rate,
     }
     att_frames++;
     for (uint32_t k = 1U; k < bins; k++) {
-      mix_e_all += (double)mix_an.power[f * bins + k];
-      out_e_all += (double)out_an.power[f * bins + k];
+      const double mk = (double)mix_an.power[f * bins + k];
+      const double ok = (double)out_an.power[f * bins + k];
+      mix_e_all += mk;
+      out_e_all += ok;
       if (noise_bins[k]) {
-        mix_e += (double)mix_an.power[f * bins + k];
-        out_e += (double)out_an.power[f * bins + k];
+        mix_e += mk;
+        out_e += ok;
+      }
+      if (k >= tonal_lo && k <= tonal_hi) {
+        tonal_mix_e += mk;
+        tonal_out_e += ok;
+      } else if (k >= halo_lo && k <= halo_hi) {
+        halo_mix_e += mk;
+        halo_out_e += ok;
       }
     }
   }
   TEST_ASSERT(att_frames >= MIN_METRIC_FRAMES, "enough noise-only frames");
   m.att_db = (float)(10.0 * log10(mix_e / out_e));
   m.att_all_db = (float)(10.0 * log10(mix_e_all / out_e_all));
+  m.tonal_att_db = (tonal_out_e > 0.0)
+                       ? (float)(10.0 * log10(tonal_mix_e / tonal_out_e))
+                       : 0.0F;
+  m.halo_att_db = (halo_out_e > 0.0)
+                      ? (float)(10.0 * log10(halo_mix_e / halo_out_e))
+                      : 0.0F;
   free(noise_psd);
   free(noise_bins);
 
@@ -1237,8 +1276,8 @@ int main(void) {
     }
     for (uint32_t mode = 0U; mode < NUM_MODES; mode++) {
       printf("== %s | %s ==\n", config->name, mode_name(mode));
-      Metrics agg = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
-                     0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+      Metrics agg = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
+                     0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
       for (uint32_t c = 0U; c < NUM_CASES; c++) {
         Signals* sig = &signals[c];
         sig->case_name = CASES[c].name;
@@ -1270,11 +1309,15 @@ int main(void) {
         agg.decay_db += m.decay_db;
         agg.sisdr_db += m.sisdr_db;
         agg.sar_db += m.sar_db;
+        agg.tonal_att_db += m.tonal_att_db;
+        agg.halo_att_db += m.halo_att_db;
         printf(
             "  %s: att %.1f dB (all %.1f), sd %.1f dB, mni %.2f (raw "
             "%.2f), decay %.1f dB, sisdr %.1f dB, sar %.1f dB\n",
             CASES[c].name, m.att_db, m.att_all_db, m.sd_db, m.mni_ratio,
             m.mni_out, m.decay_db, m.sisdr_db, m.sar_db);
+        printf("    [tonal A/B] peak-bin att %.1f dB, halo att %.1f dB\n",
+               m.tonal_att_db, m.halo_att_db);
         printf(
             "    sd split: LF %.1f dB, MF %.1f dB, HF %.1f dB | tr %.1f dB, "
             "st %.1f dB\n",
@@ -1297,6 +1340,8 @@ int main(void) {
       agg.decay_db /= (float)NUM_CASES;
       agg.sisdr_db /= (float)NUM_CASES;
       agg.sar_db /= (float)NUM_CASES;
+      agg.tonal_att_db /= (float)NUM_CASES;
+      agg.halo_att_db /= (float)NUM_CASES;
       const float sd_per_att =
           (agg.att_db > 0.01F) ? agg.sd_db / agg.att_db : 0.0F;
       printf(
@@ -1304,6 +1349,8 @@ int main(void) {
           "%.1f dB, sisdr %.1f dB, sar %.1f dB, sd/att %.2f\n",
           agg.att_db, agg.att_all_db, agg.sd_db, agg.mni_ratio, agg.decay_db,
           agg.sisdr_db, agg.sar_db, sd_per_att);
+      printf("    [tonal A/B] agg peak-bin att %.1f dB, halo att %.1f dB\n",
+             agg.tonal_att_db, agg.halo_att_db);
       printf(
           "    sd split: LF %.1f dB, MF %.1f dB, HF %.1f dB | tr %.1f dB, "
           "st %.1f dB\n",

--- a/tests/test_quality_metrics.c
+++ b/tests/test_quality_metrics.c
@@ -60,6 +60,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #define SYLLABLE_ON 0.30F  // seconds voiced
 #define SYLLABLE_OFF 0.20F // seconds unvoiced (noise-only, MNI window)
 
+// Synthetic tonal contaminant in the noise (a 2300 Hz hum fading in/out).
+// The learn segment contains it, so the profile and the tonal mask catch it;
+// the gap frames score how the tonal path + smoother treat it (and its
+// spectral neighborhood).
+#define HUM_FREQ 2300.0F
+
 // Exclude smoother transition zones around voiced/silent boundaries so the
 // metrics score steady-state behavior, not the (intentional) release tail
 #define BOUNDARY_EXCLUSION_SEC 0.12F
@@ -98,6 +104,15 @@ typedef struct Metrics {
   float lsd;         // speech distortion in dB (lower = less underwater)
   float residual_db; // mean residual level in noise-only gaps, dB over the
                      // unprocessed noise level (lower = deeper rejection)
+  // Tonal-region metrics (measurement bed for the tonal decoupling A/B):
+  // relative residual levels (dB vs the unprocessed mix in the SAME bin
+  // region) over noise-only gap frames.
+  float tonal_resid_db;   // at the hum bins (how far the tonal component is
+                          // knocked down; lower = deeper tonal rejection)
+  float halo_resid_db;    // at the bins flanking the hum (the over-suppression
+                          // "halo" the spatial smoother smears tonal carving
+                          // into; lower = wider spill, higher = tighter)
+  float control_resid_db; // far-from-hum broadband reference
 } Metrics;
 
 static void synthesize_inputs(float* clean, float* mix) {
@@ -110,9 +125,12 @@ static void synthesize_inputs(float* clean, float* mix) {
     // plus a tonal hum fading in and out (classic musical noise trigger:
     // bins toggle between cut-through and cut-to-floor)
     float breath = 1.0F + (0.5F * sinf(2.0F * M_PIf * 0.5F * t));
-    float hum = 0.08F *
-                (0.5F + (0.5F * sinf(2.0F * M_PIf * 0.33F * t + 1.0F))) *
-                sinf(2.0F * M_PIf * 2300.0F * t);
+    // Tonal hum: strong enough to stand above the broadband background so
+    // the tonal detector and the profile split actually engage the tonal
+    // path (the A/B bed needs the mask populated).
+    float hum = 2.4F *
+                (0.35F + (0.25F * sinf(2.0F * M_PIf * 0.33F * t + 1.0F))) *
+                sinf(2.0F * M_PIf * HUM_FREQ * t);
     float noise = (3.0F * noise_state * breath) + hum;
 
     float cycle = fmodf(t, SYLLABLE_ON + SYLLABLE_OFF);
@@ -254,7 +272,7 @@ static uint32_t measure_stream_delay(uint32_t smoothing_mode) {
 
 static Metrics compute_metrics(const Analyzer* clean_an, const Analyzer* out_an,
                                const Analyzer* mix_an) {
-  Metrics result = {0.0F, 0.0F};
+  Metrics result = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
   const uint32_t bins = ANALYSIS_FFT / 2U;
   const float eps = 1e-20F;
 
@@ -331,9 +349,23 @@ static Metrics compute_metrics(const Analyzer* clean_an, const Analyzer* out_an,
   result.mni = cv_sum / (float)cv_bins;
   free(frame_energy);
 
-  // Mean residual level in gaps relative to the unprocessed noise level
+  // Mean residual level in gaps relative to the unprocessed noise level,
+  // plus the tonal-decoupling A/B regional breakdown. The synthetic hum sits
+  // at HUM_FREQ (analysis bins ~9 Hz wide... 44100/1024 ~ 43 Hz):
+  //  - tonal region: bins around the hum (rejection of the tonal component)
+  //  - halo region: bins flanking it + next harmonic (the smoother/tonal
+  //    carve spill the decoupling is supposed to remove)
+  //  - control region: a hum-free band as the broadband reference
+  const int hum_bin = (int)lroundf((float)HUM_FREQ /
+                                   ((float)SAMPLE_RATE / (float)ANALYSIS_FFT));
   float res_sum = 0.0F;
   float noise_sum = 0.0F;
+  float tonal_out = 0.0F;
+  float tonal_mix = 0.0F;
+  float halo_out = 0.0F;
+  float halo_mix = 0.0F;
+  float control_out = 0.0F;
+  float control_mix = 0.0F;
   uint32_t res_frames = 0U;
   for (uint32_t f = 0U; f < out_an->num_frames; f++) {
     float center = ((float)(f * ANALYSIS_HOP) + (float)(ANALYSIS_FFT / 2U)) /
@@ -350,6 +382,19 @@ static Metrics compute_metrics(const Analyzer* clean_an, const Analyzer* out_an,
     for (uint32_t k = 1U; k < bins; k++) {
       out_e += out_an->power[f * bins + k];
       mix_e += mix_an->power[f * bins + k];
+      const float op = out_an->power[f * bins + k];
+      const float mp = mix_an->power[f * bins + k];
+      if (k >= (uint32_t)(hum_bin - 1U) && k <= (uint32_t)(hum_bin + 2U)) {
+        tonal_out += op;
+        tonal_mix += mp;
+      } else if (k >= (uint32_t)(hum_bin - 6U) &&
+                 k <= (uint32_t)(hum_bin + 7U)) {
+        halo_out += op;
+        halo_mix += mp;
+      } else if (k >= 34U && k <= 41U) {
+        control_out += op;
+        control_mix += mp;
+      }
     }
     res_sum += out_e;
     noise_sum += mix_e;
@@ -358,6 +403,10 @@ static Metrics compute_metrics(const Analyzer* clean_an, const Analyzer* out_an,
   TEST_ASSERT(res_frames > 10U, "enough gap frames");
   result.residual_db = 10.0F * log10f((res_sum / (float)res_frames) /
                                       (noise_sum / (float)res_frames + eps));
+  result.tonal_resid_db = 10.0F * log10f(tonal_out / (tonal_mix + eps) + eps);
+  result.halo_resid_db = 10.0F * log10f(halo_out / (halo_mix + eps) + eps);
+  result.control_resid_db =
+      10.0F * log10f(control_out / (control_mix + eps) + eps);
   // LSD: distortion on speech-dominant bins of voiced frames, away from
   // voiced/silent boundaries (envelope edges dominate there). Uses the
   // per-frame median so boundary leakage cannot skew the score.
@@ -475,7 +524,18 @@ static Metrics run_and_measure(uint32_t smoothing_mode, const float* mix,
       .smoothing_mode = smoothing_mode,
       .masking_depth = 0.5F,
       .whitening_factor = 0.5F,
+      .tonal_reduction_gain = 0.0F, // max strength: strong A/B contrast
+#ifndef TEST_TRANSIENT_PROTECTION
+      .transient_protection_enable = false,
+#endif
   };
+#if TEST_TRANSIENT_PROTECTION
+  // Measurement-only: run the synthetic bed with transient protection on so
+  // relief rearrangements are measured under full transient activity
+  // (gates enforce absolute numbers only in the default protection-off
+  // configuration).
+  parameters.transient_protection_enable = true;
+#endif
   TEST_ASSERT(specbleach_denoiser_load_parameters(handle, &parameters,
                                                   sizeof(parameters)),
               "load parameters");
@@ -598,10 +658,20 @@ int main() {
     printf(
         "  Gap residual (dB vs unprocessed, lower better): %.2f (gate %.1f)\n",
         results[m].residual_db, RESIDUAL_GATES_DB[m]);
+    printf(
+        "  [tonal A/B] hum %.2f dB | halo %.2f dB | control %.2f dB (gap "
+        "residual per region vs unprocessed same region)\n",
+        results[m].tonal_resid_db, results[m].halo_resid_db,
+        results[m].control_resid_db);
+    // Regression gates are enforced on the decoupled build only; the legacy
+    // measurement build (TONAL_DUAL_PATH=0) prints gate overruns so the full
+    // A/B table stays available.
+#if TONAL_DUAL_PATH && !defined(TEST_TRANSIENT_PROTECTION)
     TEST_ASSERT(results[m].mni < MNI_GATES[m], "MNI regression gate");
     TEST_ASSERT(results[m].lsd < LSD_GATES[m], "LSD regression gate");
     TEST_ASSERT(results[m].residual_db < RESIDUAL_GATES_DB[m],
                 "residual level regression gate");
+#endif
     free(out);
   }
 

--- a/tests/test_quality_metrics.c
+++ b/tests/test_quality_metrics.c
@@ -101,6 +101,7 @@ static float rand_uniform(void) {
 
 typedef struct Metrics {
   float mni;         // musical noise index (lower = cleaner residual)
+  float sustain_mni; // musical noise over voiced frames, noise-dominant bins
   float lsd;         // speech distortion in dB (lower = less underwater)
   float residual_db; // mean residual level in noise-only gaps, dB over the
                      // unprocessed noise level (lower = deeper rejection)
@@ -151,6 +152,130 @@ static void synthesize_inputs(float* clean, float* mix) {
     clean[n] = speech;
     mix[n] = speech + noise;
   }
+}
+
+// Plucked-string bed (fast attack, exponential decay): the material the
+// transient-protection sustain bug shows up on. Unlike the speech bed, the
+// envelope only decays after the onset, so the detector fires at the attack
+// and not through the body — isolating whether relief keeps overriding the
+// smoothed gain past the onset.
+#define PLUCK_FREQ 220.0F
+#define PLUCK_PERIOD_SEC 0.5F
+#define PLUCK_START_SEC 1.2F
+#define PLUCK_DECAY_WIN_A 0.04F // sustain window after each onset, seconds
+#define PLUCK_DECAY_WIN_B 0.18F
+
+static void synthesize_plucks(float* clean, float* mix) {
+  const uint32_t pluck_start = (uint32_t)(PLUCK_START_SEC * (float)SAMPLE_RATE);
+  const uint32_t pluck_period =
+      (uint32_t)(PLUCK_PERIOD_SEC * (float)SAMPLE_RATE);
+  const uint32_t pluck_len = SAMPLE_RATE / 2U;
+  const uint32_t attack = (SAMPLE_RATE * 3U) / 1000U;
+  const float amps[4] = {1.0F, 0.5F, 0.33F, 0.25F};
+  float noise_state = 0.0F;
+  for (uint32_t n = 0U; n < TOTAL_SAMPLES; n++) {
+    noise_state = (0.85F * noise_state) + (0.15F * rand_uniform());
+    float speech = 0.0F;
+    for (uint32_t t = pluck_start; t + pluck_len < TOTAL_SAMPLES;
+         t += pluck_period) {
+      if (n >= t && n < t + pluck_len) {
+        uint32_t j = n - t;
+        float env =
+            (j < attack)
+                ? (float)j / (float)attack
+                : expf(-(float)(j - attack) / (0.150F * (float)SAMPLE_RATE));
+        float s = 0.0F;
+        for (uint32_t h = 0U; h < 4U; h++) {
+          s += amps[h] * sinf(2.0F * M_PIf * PLUCK_FREQ * (float)(h + 1U) *
+                              (float)j / (float)SAMPLE_RATE);
+        }
+        speech += 0.35F * env * s / 2.08F;
+      }
+    }
+    clean[n] = speech;
+    mix[n] = speech + (1.5F * noise_state);
+  }
+}
+
+// Musical noise across the pluck sustain: spectral-shape CV over the decay
+// windows, in bins away from the 220 Hz harmonic series (noise-only), so a
+// smoothed residual scores low and a flickery one scores high.
+static float pluck_sustain_mni(const float* power, uint32_t num_frames,
+                               float stream_delay_sec) {
+  const uint32_t bins = ANALYSIS_FFT / 2U;
+  const float eps = 1e-20F;
+  const float bin_hz = (float)SAMPLE_RATE / (float)ANALYSIS_FFT;
+  const uint32_t pluck_start = (uint32_t)(PLUCK_START_SEC * (float)SAMPLE_RATE);
+  const uint32_t pluck_period =
+      (uint32_t)(PLUCK_PERIOD_SEC * (float)SAMPLE_RATE);
+  const uint32_t pluck_len = SAMPLE_RATE / 2U;
+
+  float* frame_energy = (float*)calloc(num_frames, sizeof(float));
+  TEST_ASSERT(frame_energy != NULL, "pluck frame energy alloc");
+  for (uint32_t f = 0U; f < num_frames; f++) {
+    float e = 0.0F;
+    for (uint32_t k = 1U; k < bins; k++) {
+      e += power[f * bins + k];
+    }
+    frame_energy[f] = e;
+  }
+
+  float cv_sum = 0.0F;
+  uint32_t cv_bins = 0U;
+  for (uint32_t k = 1U; k < bins - 1U; k++) {
+    bool near_harmonic = false;
+    for (uint32_t h = 1U; h <= 12U; h++) {
+      float hz = PLUCK_FREQ * (float)h;
+      if (hz >= 0.5F * (float)SAMPLE_RATE) {
+        break;
+      }
+      int hb = (int)lroundf(hz / bin_hz);
+      if ((int)k >= hb - 2 && (int)k <= hb + 2) {
+        near_harmonic = true;
+        break;
+      }
+    }
+    if (near_harmonic) {
+      continue;
+    }
+
+    float mean = 0.0F;
+    float sq_sum = 0.0F;
+    uint32_t count = 0U;
+    for (uint32_t f = 0U; f < num_frames; f++) {
+      float center = ((float)(f * ANALYSIS_HOP) + (float)(ANALYSIS_FFT / 2U)) /
+                     (float)SAMPLE_RATE;
+      bool in_decay = false;
+      for (uint32_t t = pluck_start; t + pluck_len < TOTAL_SAMPLES;
+           t += pluck_period) {
+        float rel = center - stream_delay_sec - ((float)t / (float)SAMPLE_RATE);
+        if (rel >= PLUCK_DECAY_WIN_A && rel <= PLUCK_DECAY_WIN_B) {
+          in_decay = true;
+          break;
+        }
+      }
+      if (!in_decay) {
+        continue;
+      }
+      float norm = frame_energy[f] + eps;
+      float p = (0.5F * power[f * bins + k] + 0.25F * power[f * bins + k - 1] +
+                 0.25F * power[f * bins + k + 1]) /
+                norm;
+      mean += p;
+      sq_sum += p * p;
+      count++;
+    }
+    if (count > 1U && mean > eps) {
+      mean /= (float)count;
+      float variance = sq_sum / (float)count - mean * mean;
+      if (variance > 0.0F) {
+        cv_sum += sqrtf(variance) / mean;
+        cv_bins++;
+      }
+    }
+  }
+  free(frame_energy);
+  return (cv_bins > 0U) ? (cv_sum / (float)cv_bins) : 0.0F;
 }
 
 // Frame-wise analysis STFT (Hann window, ANALYSIS_FFT / ANALYSIS_HOP)
@@ -272,7 +397,7 @@ static uint32_t measure_stream_delay(uint32_t smoothing_mode) {
 
 static Metrics compute_metrics(const Analyzer* clean_an, const Analyzer* out_an,
                                const Analyzer* mix_an) {
-  Metrics result = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+  Metrics result = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
   const uint32_t bins = ANALYSIS_FFT / 2U;
   const float eps = 1e-20F;
 
@@ -347,6 +472,56 @@ static Metrics compute_metrics(const Analyzer* clean_an, const Analyzer* out_an,
     }
   }
   result.mni = cv_sum / (float)cv_bins;
+
+  // Sustain musical noise: same spectral-shape CV, but over VOICED frames and
+  // restricted to bins where the clean reference is weak relative to the mix
+  // (inter-harmonic noise). This is the axis transient protection hits when it
+  // overrides the gain smoother through a pluck's sustain instead of only at
+  // the onset.
+  float sustain_cv_sum = 0.0F;
+  uint32_t sustain_cv_bins = 0U;
+  for (uint32_t k = 1U; k < bins - 1U; k++) {
+    float mean = 0.0F;
+    float sq_sum = 0.0F;
+    uint32_t count = 0U;
+    for (uint32_t f = 0U; f < out_an->num_frames; f++) {
+      float center = ((float)(f * ANALYSIS_HOP) + (float)(ANALYSIS_FFT / 2U)) /
+                     (float)SAMPLE_RATE;
+      if (center < ((float)LEARN_SAMPLES / (float)SAMPLE_RATE) ||
+          !frame_is_voiced(center) ||
+          boundary_distance(center) < GAP_EXCLUSION_SEC) {
+        continue;
+      }
+      float clean_p = 0.5F * clean_an->power[f * bins + k] +
+                      0.25F * clean_an->power[f * bins + k - 1] +
+                      0.25F * clean_an->power[f * bins + k + 1];
+      float mix_p = 0.5F * mix_an->power[f * bins + k] +
+                    0.25F * mix_an->power[f * bins + k - 1] +
+                    0.25F * mix_an->power[f * bins + k + 1];
+      if (clean_p > 0.25F * mix_p) {
+        continue; // signal-dominant bin this frame
+      }
+      float norm = frame_energy[f] + eps;
+      float p = (0.5F * out_an->power[f * bins + k] +
+                 0.25F * out_an->power[f * bins + k - 1] +
+                 0.25F * out_an->power[f * bins + k + 1]) /
+                norm;
+      mean += p;
+      sq_sum += p * p;
+      count++;
+    }
+    if (count > 1U && mean > eps) {
+      mean /= (float)count;
+      float variance = sq_sum / (float)count - mean * mean;
+      if (variance > 0.0F) {
+        sustain_cv_sum += sqrtf(variance) / mean;
+        sustain_cv_bins++;
+      }
+    }
+  }
+  result.sustain_mni =
+      (sustain_cv_bins > 0U) ? (sustain_cv_sum / (float)sustain_cv_bins) : 0.0F;
+
   free(frame_energy);
 
   // Mean residual level in gaps relative to the unprocessed noise level,
@@ -507,12 +682,19 @@ static const char* mode_name(uint32_t mode) {
   }
 }
 
-// Runs the full pipeline (learn -> process -> determinism probe) for one
-// smoothing mode and returns its metrics
-static Metrics run_and_measure(uint32_t smoothing_mode, const float* mix,
-                               const float* clean, float* out, Analyzer* out_an,
-                               Analyzer* clean_an, Analyzer* mix_an) {
-  printf("== %s ==\n", mode_name(smoothing_mode));
+// Per-build transient-protection setting (the measurement A/B toggles still
+// drive the default absolute gates).
+#if defined(TEST_TRANSIENT_PROTECTION) && TEST_TRANSIENT_PROTECTION
+#define BUILD_TRANSIENT_PROTECTION true
+#else
+#define BUILD_TRANSIENT_PROTECTION false
+#endif
+
+// Runs learn -> denoise for one smoothing mode into `out`. Transient
+// protection is an explicit argument so the differential penalty test can run
+// both settings on the exact same bed.
+static void process_bed(const float* mix, float* out, uint32_t smoothing_mode,
+                        bool transient_protection) {
   specbleach_denoiser* handle =
       specbleach_denoiser_initialize(SAMPLE_RATE, FRAME_MS, 0u);
   TEST_ASSERT(handle != NULL, "denoiser initialize");
@@ -525,17 +707,8 @@ static Metrics run_and_measure(uint32_t smoothing_mode, const float* mix,
       .masking_depth = 0.5F,
       .whitening_factor = 0.5F,
       .tonal_reduction_gain = 0.0F, // max strength: strong A/B contrast
-#ifndef TEST_TRANSIENT_PROTECTION
-      .transient_protection_enable = false,
-#endif
+      .transient_protection_enable = transient_protection,
   };
-#if TEST_TRANSIENT_PROTECTION
-  // Measurement-only: run the synthetic bed with transient protection on so
-  // relief rearrangements are measured under full transient activity
-  // (gates enforce absolute numbers only in the default protection-off
-  // configuration).
-  parameters.transient_protection_enable = true;
-#endif
   TEST_ASSERT(specbleach_denoiser_load_parameters(handle, &parameters,
                                                   sizeof(parameters)),
               "load parameters");
@@ -563,33 +736,23 @@ static Metrics run_and_measure(uint32_t smoothing_mode, const float* mix,
     pos += chunk;
   }
 
-  // Determinism probe: a second instance on the same input must produce
-  // bit-identical output
+  specbleach_denoiser_free(handle);
+}
+
+// Runs the full pipeline (learn -> process -> determinism probe) for one
+// smoothing mode and returns its metrics
+static Metrics run_and_measure(uint32_t smoothing_mode, const float* mix,
+                               const float* clean, float* out, Analyzer* out_an,
+                               Analyzer* clean_an, Analyzer* mix_an) {
+  printf("== %s ==\n", mode_name(smoothing_mode));
+
+  process_bed(mix, out, smoothing_mode, BUILD_TRANSIENT_PROTECTION);
+
+  // Determinism probe: a second run on the same input must be bit-identical
   {
     float* out2 = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
-    specbleach_denoiser* handle2 =
-        specbleach_denoiser_initialize(SAMPLE_RATE, FRAME_MS, 0u);
-    TEST_ASSERT(handle2 != NULL, "second instance");
-    SpecbleachDenoiserParameters p2 = parameters;
-    p2.learn_noise = SPECBLEACH_LEARN_ALL; // parameters was already finalized
-    TEST_ASSERT(specbleach_denoiser_load_parameters(handle2, &p2, sizeof(p2)),
-                "load probe parameters");
-    uint32_t pos2 = 0U;
-    while (pos2 < LEARN_SAMPLES) {
-      uint32_t chunk =
-          (LEARN_SAMPLES - pos2 < 1764U) ? (LEARN_SAMPLES - pos2) : 1764U;
-      specbleach_denoiser_process(handle2, chunk, mix + pos2, out2 + pos2);
-      pos2 += chunk;
-    }
-    p2.learn_noise = SPECBLEACH_LEARN_OFF;
-    specbleach_denoiser_load_parameters(handle2, &p2, sizeof(p2));
-    while (pos2 < TOTAL_SAMPLES) {
-      uint32_t chunk =
-          (TOTAL_SAMPLES - pos2 < 1764U) ? (TOTAL_SAMPLES - pos2) : 1764U;
-      specbleach_denoiser_process(handle2, chunk, mix + pos2, out2 + pos2);
-      pos2 += chunk;
-    }
-    specbleach_denoiser_free(handle2);
+    TEST_ASSERT(out2 != NULL, "second instance");
+    process_bed(mix, out2, smoothing_mode, BUILD_TRANSIENT_PROTECTION);
     uint32_t diffs = 0U;
     double max_diff = 0.0;
     for (uint32_t n = 0U; n < TOTAL_SAMPLES; n++) {
@@ -608,8 +771,6 @@ static Metrics run_and_measure(uint32_t smoothing_mode, const float* mix,
     free(out2);
   }
 
-  specbleach_denoiser_free(handle);
-
   const uint32_t stream_delay = measure_stream_delay(smoothing_mode);
   printf("  stream delay: %u samples\n", stream_delay);
 
@@ -620,6 +781,149 @@ static Metrics run_and_measure(uint32_t smoothing_mode, const float* mix,
   analyzer_run(mix_an, mix, -(int)stream_delay);
 
   return compute_metrics(clean_an, out_an, mix_an);
+}
+
+// Differential transient-protection penalty. The absolute MNI gates run with
+// protection OFF (and are compiled out under TEST_TRANSIENT_PROTECTION), so
+// they cannot see the smoother state that the on-onset relief and the 200 ms
+// band hold release. Measure the SAME bed twice, protection off vs on, and
+// bound the musical-noise increase. This is the meter for tuning the
+// hold/relief trade-off; attack preservation is guarded separately in
+// test_audio_regression.
+// Budget for the sustain musical-noise increase with protection on. The
+// NLM/DFTT chain applies no transient relief (1.00 by construction); the 1D
+// temporal chain applies relief but the gain smoother owns it (~1.02-1.04).
+// 1.10 leaves headroom for tuning while still catching a relief rearrangement
+// that starts leaking unsmoothed gain into a note's sustain.
+#define TRANSIENT_MNI_PENALTY_GATE 1.10F
+
+static void test_transient_protection_penalty(const float* mix,
+                                              const float* clean,
+                                              Analyzer* clean_an,
+                                              Analyzer* mix_an) {
+  const uint32_t modes[2] = {SPECBLEACH_SMOOTHING_TEMPORAL,
+                             SPECBLEACH_SMOOTHING_NLM_2D_DFTT};
+  const uint32_t num_frames =
+      (TOTAL_SAMPLES - ANALYSIS_FFT) / ANALYSIS_HOP + 1U;
+  float sustain_penalties[2] = {0.0F, 0.0F};
+
+  printf("== transient protection musical-noise penalty (off vs on) ==\n");
+  for (uint32_t m = 0U; m < 2U; m++) {
+    const uint32_t mode = modes[m];
+    float* out_off = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
+    float* out_on = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
+    TEST_ASSERT(out_off != NULL && out_on != NULL, "penalty output alloc");
+
+    process_bed(mix, out_off, mode, false);
+    process_bed(mix, out_on, mode, true);
+
+    const uint32_t stream_delay = measure_stream_delay(mode);
+    analyzer_run(clean_an, clean, -(int)stream_delay);
+    analyzer_run(mix_an, mix, -(int)stream_delay);
+
+    Analyzer off_an;
+    Analyzer on_an;
+    analyzer_init(&off_an, num_frames);
+    analyzer_init(&on_an, num_frames);
+    analyzer_run(&off_an, out_off, 0);
+    analyzer_run(&on_an, out_on, 0);
+
+    const Metrics m_off = compute_metrics(clean_an, &off_an, mix_an);
+    const Metrics m_on = compute_metrics(clean_an, &on_an, mix_an);
+    const float penalty = m_on.mni / m_off.mni;
+    const float sustain_penalty = m_on.sustain_mni / m_off.sustain_mni;
+    sustain_penalties[m] = sustain_penalty;
+    const float noise_let_through_db = m_on.residual_db - m_off.residual_db;
+    printf(
+        "  %-12s gapMNI off=%.4f on=%.4f pen=%.3f | sustainMNI off=%.4f "
+        "on=%.4f pen=%.3f | residual %+.2f dB\n",
+        mode_name(mode), m_off.mni, m_on.mni, penalty, m_off.sustain_mni,
+        m_on.sustain_mni, sustain_penalty, noise_let_through_db);
+
+    analyzer_free(&off_an);
+    analyzer_free(&on_an);
+    free(out_off);
+    free(out_on);
+  }
+
+  // Report both modes first, then gate, so a failure still prints the full
+  // table. The sustain axis is the one transient protection corrupts when it
+  // overrides the smoother past the onset; enforced on the decoupled build
+  // (legacy A/B builds print only).
+#if TONAL_DUAL_PATH
+  for (uint32_t m = 0U; m < 2U; m++) {
+    if (sustain_penalties[m] >= TRANSIENT_MNI_PENALTY_GATE) {
+      fprintf(stderr,
+              "FAIL: %s transient-protection sustain musical-noise penalty "
+              "%.3f >= target %.2f\n",
+              mode_name(modes[m]), sustain_penalties[m],
+              TRANSIENT_MNI_PENALTY_GATE);
+      exit(1);
+    }
+  }
+#endif
+}
+
+// Pluck-sustain differential: runs the pluck bed with smoothing on and bounds
+// the sustain musical-noise increase. This is the axis the UI LED/onset vs
+// 200 ms relief-hold mismatch corrupts on plucked material.
+static void test_pluck_sustain_penalty(void) {
+  float* clean = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
+  float* mix = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
+  TEST_ASSERT(clean != NULL && mix != NULL, "pluck bed alloc");
+  synthesize_plucks(clean, mix);
+
+  const uint32_t modes[2] = {SPECBLEACH_SMOOTHING_TEMPORAL,
+                             SPECBLEACH_SMOOTHING_NLM_2D_DFTT};
+  const uint32_t num_frames =
+      (TOTAL_SAMPLES - ANALYSIS_FFT) / ANALYSIS_HOP + 1U;
+  float pluck_penalties[2] = {0.0F, 0.0F};
+
+  printf("== pluck sustain musical noise (off vs on) ==\n");
+  for (uint32_t m = 0U; m < 2U; m++) {
+    float* out_off = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
+    float* out_on = (float*)calloc(TOTAL_SAMPLES, sizeof(float));
+    TEST_ASSERT(out_off != NULL && out_on != NULL, "pluck output alloc");
+    process_bed(mix, out_off, modes[m], false);
+    process_bed(mix, out_on, modes[m], true);
+
+    const uint32_t stream_delay = measure_stream_delay(modes[m]);
+    Analyzer off_an;
+    Analyzer on_an;
+    analyzer_init(&off_an, num_frames);
+    analyzer_init(&on_an, num_frames);
+    analyzer_run(&off_an, out_off, 0);
+    analyzer_run(&on_an, out_on, 0);
+    const float delay_sec = (float)stream_delay / (float)SAMPLE_RATE;
+    const float mni_off =
+        pluck_sustain_mni(off_an.power, off_an.num_frames, delay_sec);
+    const float mni_on =
+        pluck_sustain_mni(on_an.power, on_an.num_frames, delay_sec);
+    pluck_penalties[m] = mni_on / mni_off;
+    printf("  %-12s sustainMNI off=%.4f on=%.4f penalty=%.3f\n",
+           mode_name(modes[m]), mni_off, mni_on, pluck_penalties[m]);
+
+    analyzer_free(&off_an);
+    analyzer_free(&on_an);
+    free(out_off);
+    free(out_on);
+  }
+
+  // Enforced on the decoupled build (legacy A/B builds print only).
+#if TONAL_DUAL_PATH
+  for (uint32_t m = 0U; m < 2U; m++) {
+    if (pluck_penalties[m] >= TRANSIENT_MNI_PENALTY_GATE) {
+      fprintf(stderr,
+              "FAIL: %s pluck-sustain musical-noise penalty %.3f >= target "
+              "%.2f\n",
+              mode_name(modes[m]), pluck_penalties[m],
+              TRANSIENT_MNI_PENALTY_GATE);
+      exit(1);
+    }
+  }
+#endif
+  free(clean);
+  free(mix);
 }
 
 int main() {
@@ -674,6 +978,9 @@ int main() {
 #endif
     free(out);
   }
+
+  test_pluck_sustain_penalty();
+  test_transient_protection_penalty(mix, clean, &clean_an, &mix_an);
 
   printf("MNI ratio NLM/Temporal: %.3f, DFTT/Temporal: %.3f\n",
          results[1].mni / results[0].mni, results[2].mni / results[0].mni);

--- a/tests/test_spectral_utils.c
+++ b/tests/test_spectral_utils.c
@@ -412,6 +412,54 @@ void test_spectral_envelope_opening(void) {
   // Inputs are never modified (const contract).
   TEST_FLOAT_CLOSE(spectrum[64], 20.0f, 1e-6f);
 
+  // Monotonic baselines: trailing erosion + leading dilation is a zero-phase
+  // pair, so ramps survive unshifted (a same-orientation opening would delay
+  // the envelope by a full window).
+  for (uint32_t k = 0U; k < size; k++) {
+    spectrum[k] = (float)k;
+  }
+  TEST_ASSERT(sb_spectral_envelope_opening(spectrum, scratch, env, size, 6),
+              "increasing ramp opening runs");
+  for (uint32_t k = 16U; k + 16U < size; k++) {
+    TEST_FLOAT_CLOSE(env[k], spectrum[k], 1e-3f);
+  }
+
+  for (uint32_t k = 0U; k < size; k++) {
+    spectrum[k] = (float)(size - 1U - k);
+  }
+  TEST_ASSERT(sb_spectral_envelope_opening(spectrum, scratch, env, size, 6),
+              "decreasing ramp opening runs");
+  for (uint32_t k = 16U; k + 16U < size; k++) {
+    TEST_FLOAT_CLOSE(env[k], spectrum[k], 1e-3f);
+  }
+
+  // A step edge keeps its location (no window delay) and stays monotonic.
+  for (uint32_t k = 0U; k < size; k++) {
+    spectrum[k] = (k < size / 2U) ? 0.0f : 1.0f;
+  }
+  TEST_ASSERT(sb_spectral_envelope_opening(spectrum, scratch, env, size, 6),
+              "step opening runs");
+  TEST_FLOAT_CLOSE(env[size / 4U], 0.0f, 1e-3f);
+  TEST_FLOAT_CLOSE(env[(3U * size) / 4U], 1.0f, 1e-3f);
+  for (uint32_t k = 1U; k < size; k++) {
+    if (env[k] < env[k - 1] - 1e-6f) {
+      fprintf(stderr, "FAIL: step opening not monotonic at bin %u\n", k);
+      exit(1);
+    }
+  }
+
+  // Narrowband peaks close to the edges are still lifted out: the trailing
+  // erosion window always has enough floor next to them.
+  for (uint32_t k = 0U; k < size; k++) {
+    spectrum[k] = floor_level;
+  }
+  spectrum[2U] = 20.0f;
+  spectrum[size - 3U] = 20.0f;
+  TEST_ASSERT(sb_spectral_envelope_opening(spectrum, scratch, env, size, 6),
+              "edge peak opening runs");
+  TEST_FLOAT_CLOSE(env[2U], floor_level, 0.2f);
+  TEST_FLOAT_CLOSE(env[size - 3U], floor_level, 0.2f);
+
   printf("✓ sb_spectral_envelope_opening tests passed\n");
 }
 

--- a/tests/test_spectral_utils.c
+++ b/tests/test_spectral_utils.c
@@ -18,6 +18,7 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include "shared/configurations.h"
 #include "shared/utils/spectral_utils.h"
 #include <math.h>
 #include <stdio.h>
@@ -371,6 +372,49 @@ void test_get_morphed_profile(void) {
   printf("✓ get_morphed_profile tests passed\n");
 }
 
+void test_spectral_envelope_opening(void) {
+  printf("Testing sb_spectral_envelope_opening...\n");
+
+  const uint32_t size = 256;
+  const float floor_level = 1.0f;
+  float spectrum[size];
+  float scratch[size];
+  float env[size];
+
+  // Error paths
+  TEST_ASSERT(!sb_spectral_envelope_opening(NULL, scratch, env, size, 6),
+              "NULL spectrum check");
+  TEST_ASSERT(!sb_spectral_envelope_opening(spectrum, scratch, env, size, 0),
+              "Zero window check");
+  TEST_ASSERT(!sb_spectral_envelope_opening(spectrum, scratch, env, size,
+                                            TONAL_DETONE_MAX_BINS + 1U),
+              "Window overflow check");
+
+  // Flat floor + narrow single-bin peaks (tonal spikes).
+  for (uint32_t k = 0U; k < size; k++) {
+    spectrum[k] = floor_level;
+  }
+  spectrum[64] = 20.0f;
+  spectrum[129] = 15.0f;
+  spectrum[130] = 15.0f;
+
+  TEST_ASSERT(sb_spectral_envelope_opening(spectrum, scratch, env, size, 6),
+              "opening runs");
+  // Peaks are lifted out: envelope stays near the floor at the peak bins.
+  TEST_FLOAT_CLOSE(env[64], floor_level, 0.2f);
+  TEST_FLOAT_CLOSE(env[129], floor_level, 0.2f);
+  TEST_FLOAT_CLOSE(env[130], floor_level, 0.2f);
+  // Broadband baseline is preserved between peaks (not over-eroded).
+  TEST_FLOAT_CLOSE(env[100], floor_level, 0.2f);
+  TEST_FLOAT_CLOSE(env[0], floor_level, 0.2f);
+  TEST_FLOAT_CLOSE(env[size - 1], floor_level, 0.2f);
+
+  // Inputs are never modified (const contract).
+  TEST_FLOAT_CLOSE(spectrum[64], 20.0f, 1e-6f);
+
+  printf("✓ sb_spectral_envelope_opening tests passed\n");
+}
+
 int main(void) {
   printf("Running spectral_utils tests...\n\n");
 
@@ -383,6 +427,7 @@ int main(void) {
   test_smooth_spectrum();
   test_interpolate_spectrum_gaps();
   test_get_morphed_profile();
+  test_spectral_envelope_opening();
 
   printf("\n✅ All spectral_utils tests passed!\n");
   return 0;

--- a/tests/test_tonal_reducer.c
+++ b/tests/test_tonal_reducer.c
@@ -20,7 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 /*
 libspecbleach - A spectral processing library
-Test suite for the Tonal Reducer module.
+Test suite for the Tonal Reducer module (dual-path split + parallel tonal
+gain path).
 */
 
 #include "shared/denoiser_logic/processing/tonal_reducer.h"
@@ -58,103 +59,210 @@ void test_initialization(void) {
   printf("✓ Initialization passed\n");
 }
 
-void test_flat_noise_no_boost(void) {
-  printf("Testing flat noise (no boost expected)...\n");
+void test_flat_noise_identity_split(void) {
+  printf("Testing flat noise (identity split, no tonal path)...\n");
   TonalReducer* reducer = tonal_reducer_initialize(
       TEST_SPECTRUM_SIZE, TEST_SAMPLE_RATE, TEST_FFT_SIZE);
 
-  float alpha[TEST_SPECTRUM_SIZE];
   float noise_spectrum[TEST_SPECTRUM_SIZE];
-  float cv_mask[TEST_SPECTRUM_SIZE];
+  float noise_bb[TEST_SPECTRUM_SIZE];
+  float noise_tonal[TEST_SPECTRUM_SIZE];
+  float gain_tonal[TEST_SPECTRUM_SIZE];
+  float smoothed[TEST_SPECTRUM_SIZE];
 
-  // Initialize with flat noise
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
-    alpha[i] = 1.0f;           // Default alpha (no oversubtraction yet)
     noise_spectrum[i] = 0.01f; // Flat noise
-    cv_mask[i] = 0.0f;
+    smoothed[i] = 0.2f;        // Somewhat above the noise
   }
 
-  // Run with no reduction requested (gain 1.0)
-  tonal_reducer_run(reducer, noise_spectrum, cv_mask, false, alpha, 1.0f);
+  // Max tonal reduction requested, adaptive mode (no CV profile)
+  tonal_reducer_compute_split(reducer, noise_spectrum, NULL, false, 0.0f,
+                              noise_bb, noise_tonal);
 
   const float* mask = tonal_reducer_get_mask(reducer);
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
     if (mask[i] > 0.0f) {
-      fprintf(stderr, "FAIL: False detection at bin %d\n", i);
+      fprintf(stderr, "FAIL: False tonal detection at bin %d\n", i);
       exit(1);
     }
-    if (alpha[i] != 1.0f) {
-      fprintf(stderr, "FAIL: Alpha modified at bin %d (expected 1.0, got %f)\n",
-              i, alpha[i]);
+    if (noise_bb[i] != noise_spectrum[i]) {
+      fprintf(stderr, "FAIL: bb profile modified at bin %d (%f vs %f)\n", i,
+              noise_bb[i], noise_spectrum[i]);
+      exit(1);
+    }
+    if (noise_tonal[i] != 0.0f) {
+      fprintf(stderr, "FAIL: Non-zero tonal residual at bin %d\n", i);
+      exit(1);
+    }
+  }
+
+  // Tonal gains must be unity everywhere (no residual)
+  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal, 0.0f,
+                                    gain_tonal);
+  for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
+    if (gain_tonal[i] != 1.0f) {
+      fprintf(stderr, "FAIL: Tonal gain not unity at bin %d\n", i);
       exit(1);
     }
   }
 
   tonal_reducer_free(reducer);
-  printf("✓ Flat noise passed (no changes)\n");
+  printf("✓ Flat noise passed (identity split)\n");
 }
 
-void test_tonal_boost(void) {
-  printf("Testing tonal boost (alpha increase)...\n");
+void test_tonal_split_and_gains(void) {
+  printf("Testing tonal split and parallel gains (CV mask)...\n");
   TonalReducer* reducer = tonal_reducer_initialize(
       TEST_SPECTRUM_SIZE, TEST_SAMPLE_RATE, TEST_FFT_SIZE);
 
-  float alpha[TEST_SPECTRUM_SIZE];
   float noise_spectrum[TEST_SPECTRUM_SIZE];
   float cv_mask[TEST_SPECTRUM_SIZE];
+  float noise_bb[TEST_SPECTRUM_SIZE];
+  float noise_tonal[TEST_SPECTRUM_SIZE];
+  float gain_tonal[TEST_SPECTRUM_SIZE];
+  float smoothed[TEST_SPECTRUM_SIZE];
 
-  // Initialize flat with realistic alpha=1.0 (ALPHA_MIN)
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
-    alpha[i] = 1.0f;
-    noise_spectrum[i] = 0.01f;
+    noise_spectrum[i] = 0.01f; // Flat noise floor
+    smoothed[i] = 0.2f;        // Signal somewhat above the noise
     cv_mask[i] = 0.0f;
   }
 
-  // Add a tone at 1 kHz in CV mask
+  // Add a tone at 1 kHz in CV mask (with energy shoulders on the masked
+  // side bins so the partial-mask softening is actually exercised)
   int bin = freq_to_bin(1000.0f);
   noise_spectrum[bin] = 0.1f;
+  noise_spectrum[bin - 1] = 0.05f;
+  noise_spectrum[bin + 1] = 0.05f;
   cv_mask[bin] = 1.0f;
   cv_mask[bin - 1] = 0.5f;
   cv_mask[bin + 1] = 0.5f;
 
-  float reduction_gain = 0.00398f; // ~48dB reduction (gain close to 0)
+  float reduction_gain = 0.0f; // max reduction strength
 
-  tonal_reducer_run(reducer, noise_spectrum, cv_mask, true, alpha,
-                    reduction_gain);
+  tonal_reducer_compute_split(reducer, noise_spectrum, cv_mask, true,
+                              reduction_gain, noise_bb, noise_tonal);
 
   const float* mask = tonal_reducer_get_mask(reducer);
-
   if (mask[bin] <= 0.0f) {
     fprintf(stderr, "FAIL: Tone not detected at bin %d\n", bin);
     exit(1);
   }
   printf("  Tone detected at bin %d (mask=%.3f)\n", bin, mask[bin]);
 
-  // Alpha should be boosted aggressively.
-  if (alpha[bin] <= 9.0f) {
-    fprintf(stderr,
-            "FAIL: Alpha not boosted aggressively (<=9.0) at tonal bin %d (got "
-            "%f)\n",
-            bin, alpha[bin]);
+  // At the mask bin the residual must be positive and the bb profile must be
+  // pushed toward the envelope (below the raw profile).
+  if (noise_tonal[bin] <= 0.0f) {
+    fprintf(stderr, "FAIL: No tonal residual at bin %d (%f)\n", bin,
+            noise_tonal[bin]);
     exit(1);
   }
-  printf("  Alpha at bin %d: %.3f (boosted aggressively) ✓\n", bin, alpha[bin]);
+  if (noise_bb[bin] >= noise_spectrum[bin]) {
+    fprintf(stderr,
+            "FAIL: bb profile not flattened at tonal bin %d (%f >= %f)\n", bin,
+            noise_bb[bin], noise_spectrum[bin]);
+    exit(1);
+  }
+  // A mask-free bin keeps the profile exactly and carries no residual.
+  if (noise_bb[bin + 10] != noise_spectrum[bin + 10] ||
+      noise_tonal[bin + 10] != 0.0f) {
+    fprintf(stderr, "FAIL: Identity split violated at mask-free bin %d\n",
+            bin + 10);
+    exit(1);
+  }
+
+  // Tonal gains: deep notch at the full-strength bin, softer at partial-mask
+  // neighbors, unity far away.
+  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal,
+                                    reduction_gain, gain_tonal);
+  if (gain_tonal[bin] > 0.5f) {
+    fprintf(stderr, "FAIL: Tonal gain not notched at bin %d (%f)\n", bin,
+            gain_tonal[bin]);
+    exit(1);
+  }
+  if (gain_tonal[bin + 10] != 1.0f) {
+    fprintf(stderr, "FAIL: Tonal gain not unity at non-tonal bin %d (%f)\n",
+            bin + 10, gain_tonal[bin + 10]);
+    exit(1);
+  }
+  if (gain_tonal[bin - 1] >= 1.0f || gain_tonal[bin - 1] <= gain_tonal[bin]) {
+    fprintf(stderr,
+            "FAIL: Partial-mask bin %d not softer than full bin %d (got %f vs "
+            "%f)\n",
+            bin - 1, bin, gain_tonal[bin - 1], gain_tonal[bin]);
+    exit(1);
+  }
+  printf("  Gains: full=%f partial=%f far=1.0 ✓\n", gain_tonal[bin],
+         gain_tonal[bin - 1]);
+
+  // Second call: one-pole tracks toward the raw gains (not deeper)
+  float gain_second[TEST_SPECTRUM_SIZE];
+  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal,
+                                    reduction_gain, gain_second);
+  if (gain_second[bin] < gain_tonal[bin] - 1e-6f || gain_second[bin] > 1.0f) {
+    fprintf(stderr, "FAIL: One-pole trajectory invalid at bin %d (%f -> %f)\n",
+            bin, gain_tonal[bin], gain_second[bin]);
+    exit(1);
+  }
 
   tonal_reducer_free(reducer);
-  printf("✓ Tonal boost passed\n");
+  printf("✓ Tonal split and gains passed\n");
 }
 
-void test_caching_and_adaptive_support(void) {
-  printf("Testing mask caching and adaptive support in tonal reducer...\n");
+void test_disabled_reduction_is_legacy(void) {
+  printf("Testing disabled tonal reduction (legacy single path)...\n");
   TonalReducer* reducer = tonal_reducer_initialize(
       TEST_SPECTRUM_SIZE, TEST_SAMPLE_RATE, TEST_FFT_SIZE);
 
-  float alpha[TEST_SPECTRUM_SIZE];
   float noise_spectrum[TEST_SPECTRUM_SIZE];
+  float cv_mask[TEST_SPECTRUM_SIZE];
+  float noise_bb[TEST_SPECTRUM_SIZE];
+  float noise_tonal[TEST_SPECTRUM_SIZE];
 
-  // 1. Initialize empty CV mask (adaptive mode)
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
-    alpha[i] = 1.0f;
+    noise_spectrum[i] = 0.01f;
+    cv_mask[i] = 0.0f;
+  }
+  int bin = freq_to_bin(1000.0f);
+  noise_spectrum[bin] = 0.1f;
+  cv_mask[bin] = 1.0f;
+
+  // Reduction disabled (gain 1.0): mask still published but the split must
+  // be a pure copy (legacy behavior).
+  tonal_reducer_compute_split(reducer, noise_spectrum, cv_mask, true, 1.0f,
+                              noise_bb, noise_tonal);
+  const float* mask = tonal_reducer_get_mask(reducer);
+  if (mask[bin] <= 0.0f) {
+    fprintf(stderr, "FAIL: Mask not published when reduction disabled\n");
+    exit(1);
+  }
+  for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
+    if (noise_bb[i] != noise_spectrum[i]) {
+      fprintf(stderr,
+              "FAIL: Disabled reduction modified bb profile at bin %d\n", i);
+      exit(1);
+    }
+    if (noise_tonal[i] != 0.0f) {
+      fprintf(stderr, "FAIL: Disabled reduction produced residual at bin %d\n",
+              i);
+      exit(1);
+    }
+  }
+
+  tonal_reducer_free(reducer);
+  printf("✓ Disabled reduction passed (legacy path)\n");
+}
+
+void test_mask_refresh_and_adaptive_support(void) {
+  printf("Testing adaptive mask refresh and manual mask support...\n");
+  TonalReducer* reducer = tonal_reducer_initialize(
+      TEST_SPECTRUM_SIZE, TEST_SAMPLE_RATE, TEST_FFT_SIZE);
+
+  float noise_spectrum[TEST_SPECTRUM_SIZE];
+  float noise_bb[TEST_SPECTRUM_SIZE];
+  float noise_tonal[TEST_SPECTRUM_SIZE];
+
+  for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
     noise_spectrum[i] = 0.01f;
   }
 
@@ -164,12 +272,9 @@ void test_caching_and_adaptive_support(void) {
   noise_spectrum[bin1 - 1] = 0.03f;
   noise_spectrum[bin1 + 1] = 0.03f;
 
-  float reduction_gain = 0.0f; // max reduction strength
-
   // Run 1: Should detect the tone at bin1 in adaptive mode
-  tonal_reducer_run(reducer, noise_spectrum, NULL, false, alpha,
-                    reduction_gain);
-
+  tonal_reducer_compute_split(reducer, noise_spectrum, NULL, false, 0.0f,
+                              noise_bb, noise_tonal);
   const float* mask = tonal_reducer_get_mask(reducer);
   if (mask[bin1] <= 0.0f) {
     fprintf(stderr,
@@ -177,31 +282,25 @@ void test_caching_and_adaptive_support(void) {
             bin1);
     exit(1);
   }
-  printf("  Run 1: Tone at bin %d detected in adaptive mode (mask=%.3f) ✓\n",
-         bin1, mask[bin1]);
-
-  // Reset alpha
-  for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
-    alpha[i] = 1.0f;
+  if (noise_tonal[bin1] <= 0.0f) {
+    fprintf(stderr, "FAIL: No residual extracted for adaptive tone at bin %d\n",
+            bin1);
+    exit(1);
   }
+  printf("  Run 1: Tone at bin %d detected in adaptive mode ✓\n", bin1);
 
-  // Move tone to bin 200 but keep the sum identical
+  // Move tone to bin 200 but keep the structure similar
   int bin2 = 200;
-  // Restore bin1 to noise floor
   noise_spectrum[bin1] = 0.01f;
   noise_spectrum[bin1 - 1] = 0.01f;
   noise_spectrum[bin1 + 1] = 0.01f;
-  // Put tone at bin2
   noise_spectrum[bin2] = 0.1f;
   noise_spectrum[bin2 - 1] = 0.03f;
   noise_spectrum[bin2 + 1] = 0.03f;
 
-  // Run 2: When noise spectrum is updated with moved tone, detection refreshes.
-  // The mask should now detect tone at bin2 and clear bin1.
-  tonal_reducer_run(reducer, noise_spectrum, NULL, false, alpha,
-                    reduction_gain);
+  tonal_reducer_compute_split(reducer, noise_spectrum, NULL, false, 0.0f,
+                              noise_bb, noise_tonal);
   mask = tonal_reducer_get_mask(reducer);
-
   if (mask[bin1] > 0.0f) {
     fprintf(stderr,
             "FAIL: Old tone at bin %d was not cleared on spectrum update\n",
@@ -214,25 +313,16 @@ void test_caching_and_adaptive_support(void) {
             bin2);
     exit(1);
   }
-  printf(
-      "  Run 2: Tonal mask refreshed on spectrum update (tone at bin %d "
-      "detected, bin %d cleared) ✓\n",
-      bin2, bin1);
+  printf("  Run 2: Tonal mask refreshed on spectrum update ✓\n", bin2);
 
-  // Reset alpha
-  for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
-    alpha[i] = 1.0f;
-  }
-
-  // Run 3: Modify spectrum again (add third tone at bin 50)
+  // Add a third tone at bin 50
   noise_spectrum[50] = 0.1f;
   noise_spectrum[49] = 0.03f;
   noise_spectrum[51] = 0.03f;
 
-  tonal_reducer_run(reducer, noise_spectrum, NULL, false, alpha,
-                    reduction_gain);
+  tonal_reducer_compute_split(reducer, noise_spectrum, NULL, false, 0.0f,
+                              noise_bb, noise_tonal);
   mask = tonal_reducer_get_mask(reducer);
-
   if (mask[50] <= 0.0f) {
     fprintf(stderr, "FAIL: New tone at bin 50 was not detected\n");
     exit(1);
@@ -241,23 +331,21 @@ void test_caching_and_adaptive_support(void) {
     fprintf(stderr, "FAIL: Existing tone at bin %d was not detected\n", bin2);
     exit(1);
   }
-  printf(
-      "  Run 3: Updated spectrum detected multiple tones (bins 50 and %d) ✓\n",
-      bin2);
+  printf("  Run 3: Multiple tones detected ✓\n");
 
-  // Run 4: Manual CV mask mode with high-frequency bin > 99
+  // Run 4: Manual CV mask mode with high-frequency bins > 99
   float manual_cv_mask[TEST_SPECTRUM_SIZE];
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
     manual_cv_mask[i] = 0.0f;
-    alpha[i] = 1.0f;
   }
   int cv_bin = 150; // Above index 99 to ensure full spectrum scanning
   manual_cv_mask[cv_bin] = 1.0f;
-  int cv_bin2 = 180; // Second high-frequency bin above index 99
+  noise_spectrum[cv_bin] = 0.1f; // Tonality needs profile energy to notch
+  int cv_bin2 = 180;             // Second high-frequency bin above index 99
   manual_cv_mask[cv_bin2] = 0.5f;
 
-  tonal_reducer_run(reducer, noise_spectrum, manual_cv_mask, true, alpha,
-                    reduction_gain);
+  tonal_reducer_compute_split(reducer, noise_spectrum, manual_cv_mask, true,
+                              0.0f, noise_bb, noise_tonal);
   mask = tonal_reducer_get_mask(reducer);
 
   if (mask[cv_bin] <= 0.0f) {
@@ -273,47 +361,37 @@ void test_caching_and_adaptive_support(void) {
             cv_bin2, mask[cv_bin2]);
     exit(1);
   }
-  if (alpha[cv_bin] <= 1.0f) {
-    fprintf(stderr, "FAIL: Alpha not boosted at manual CV bin %d\n", cv_bin);
+  if (noise_tonal[cv_bin] <= 0.0f) {
+    fprintf(stderr, "FAIL: No residual at manual CV bin %d\n", cv_bin);
     exit(1);
   }
-  if (alpha[cv_bin2] <= 1.0f || alpha[cv_bin2] >= alpha[cv_bin]) {
-    fprintf(stderr,
-            "FAIL: Alpha at fractional bin %d not smaller than full-strength "
-            "bin %d (got %f vs %f)\n",
-            cv_bin2, cv_bin, alpha[cv_bin2], alpha[cv_bin]);
-    exit(1);
-  }
-  printf(
-      "  Run 4: CV mask directly applied at bins %d and %d (above index 99) "
-      "✓\n",
-      cv_bin, cv_bin2);
+  printf("  Run 4: CV mask directly applied at bins %d and %d ✓\n", cv_bin,
+         cv_bin2);
 
-  // Run 5: Available all-zero CV mask honors profile without adaptive detection
+  // Run 5: Available all-zero CV mask honored without adaptive detection
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
     manual_cv_mask[i] = 0.0f;
-    alpha[i] = 1.0f;
   }
-  tonal_reducer_run(reducer, noise_spectrum, manual_cv_mask, true, alpha,
-                    reduction_gain);
+  tonal_reducer_compute_split(reducer, noise_spectrum, manual_cv_mask, true,
+                              0.0f, noise_bb, noise_tonal);
   mask = tonal_reducer_get_mask(reducer);
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
     if (mask[i] > 0.0f) {
+      fprintf(stderr,
+              "FAIL: Available all-zero CV mask produced non-zero mask at bin "
+              "%d\n",
+              i);
+      exit(1);
+    }
+    if (noise_bb[i] != noise_spectrum[i]) {
       fprintf(
           stderr,
-          "FAIL: Available all-zero CV mask produced non-zero mask at bin %d\n",
+          "FAIL: Available all-zero CV mask modified bb profile at bin %d\n",
           i);
       exit(1);
     }
-    if (alpha[i] != 1.0f) {
-      fprintf(stderr,
-              "FAIL: Available all-zero CV mask modified alpha at bin %d\n", i);
-      exit(1);
-    }
   }
-  printf(
-      "  Run 5: Available all-zero CV mask honored without adaptive detection "
-      "✓\n");
+  printf("  Run 5: Available all-zero CV mask honored ✓\n");
 
   tonal_reducer_free(reducer);
   printf("✓ Adaptive support and manual mask tests passed\n");
@@ -338,11 +416,12 @@ void test_tonal_reducer_peaks(void) {
     exit(1);
   }
 
-  float alpha[TEST_SPECTRUM_SIZE];
-  float noise[TEST_SPECTRUM_SIZE] = {0.01f};
-  float cv_mask[TEST_SPECTRUM_SIZE] = {0.0f};
-  // Gain 1.0f (no reduction requested, short-circuits early)
-  tonal_reducer_run(reducer, noise, cv_mask, false, alpha, 1.0f);
+  float noise_spectrum[TEST_SPECTRUM_SIZE] = {0.01f};
+  float noise_bb[TEST_SPECTRUM_SIZE];
+  float noise_tonal[TEST_SPECTRUM_SIZE];
+  // Gain 1.0f (no reduction requested, split short-circuits)
+  tonal_reducer_compute_split(reducer, noise_spectrum, NULL, false, 1.0f,
+                              noise_bb, noise_tonal);
 
   tonal_reducer_free(reducer);
   printf("✓ Tonal reducer peaks test passed\n");
@@ -351,9 +430,10 @@ void test_tonal_reducer_peaks(void) {
 int main(void) {
   printf("=== Tonal Reducer Tests ===\n\n");
   test_initialization();
-  test_flat_noise_no_boost();
-  test_tonal_boost();
-  test_caching_and_adaptive_support();
+  test_flat_noise_identity_split();
+  test_tonal_split_and_gains();
+  test_disabled_reduction_is_legacy();
+  test_mask_refresh_and_adaptive_support();
   test_tonal_reducer_peaks();
   printf("\n=== All tonal reducer tests passed ===\n");
   return 0;

--- a/tests/test_tonal_reducer.c
+++ b/tests/test_tonal_reducer.c
@@ -97,8 +97,8 @@ void test_flat_noise_identity_split(void) {
   }
 
   // Tonal gains must be unity everywhere (no residual)
-  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal, 0.0f,
-                                    gain_tonal);
+  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal, mask,
+                                    0.0f, gain_tonal);
   for (int i = 0; i < TEST_SPECTRUM_SIZE; i++) {
     if (gain_tonal[i] != 1.0f) {
       fprintf(stderr, "FAIL: Tonal gain not unity at bin %d\n", i);
@@ -173,7 +173,7 @@ void test_tonal_split_and_gains(void) {
 
   // Tonal gains: deep notch at the full-strength bin, softer at partial-mask
   // neighbors, unity far away.
-  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal,
+  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal, mask,
                                     reduction_gain, gain_tonal);
   if (gain_tonal[bin] > 0.5f) {
     fprintf(stderr, "FAIL: Tonal gain not notched at bin %d (%f)\n", bin,
@@ -195,13 +195,39 @@ void test_tonal_split_and_gains(void) {
   printf("  Gains: full=%f partial=%f far=1.0 ✓\n", gain_tonal[bin],
          gain_tonal[bin - 1]);
 
-  // Second call: one-pole tracks toward the raw gains (not deeper)
+  // Second call: feed a changed magnitude so the raw target moves up. The
+  // one-pole must land strictly between the seeded gain and the new raw target
+  // (a fresh reducer's first call exposes that unstabilized target).
+  const int probe = bin - 1; // partial-mask bin: unsaturated and movable
+  float smoothed_second[TEST_SPECTRUM_SIZE];
+  memcpy(smoothed_second, smoothed, sizeof(smoothed));
+  smoothed_second[probe] = 0.5f; // more signal -> higher raw gain
   float gain_second[TEST_SPECTRUM_SIZE];
-  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed, noise_tonal,
-                                    reduction_gain, gain_second);
+  tonal_reducer_compute_tonal_gains(reducer, 0U, smoothed_second, noise_tonal,
+                                    mask, reduction_gain, gain_second);
   if (gain_second[bin] < gain_tonal[bin] - 1e-6f || gain_second[bin] > 1.0f) {
     fprintf(stderr, "FAIL: One-pole trajectory invalid at bin %d (%f -> %f)\n",
             bin, gain_tonal[bin], gain_second[bin]);
+    exit(1);
+  }
+
+  TonalReducer* fresh = tonal_reducer_initialize(
+      TEST_SPECTRUM_SIZE, TEST_SAMPLE_RATE, TEST_FFT_SIZE);
+  float fresh_bb[TEST_SPECTRUM_SIZE];
+  float fresh_tonal[TEST_SPECTRUM_SIZE];
+  tonal_reducer_compute_split(fresh, noise_spectrum, cv_mask, true,
+                              reduction_gain, fresh_bb, fresh_tonal);
+  float target[TEST_SPECTRUM_SIZE];
+  tonal_reducer_compute_tonal_gains(fresh, 0U, smoothed_second, fresh_tonal,
+                                    tonal_reducer_get_mask(fresh),
+                                    reduction_gain, target);
+  tonal_reducer_free(fresh);
+  if (!(gain_second[probe] > gain_tonal[probe] + 1e-6f &&
+        gain_second[probe] < target[probe] - 1e-6f)) {
+    fprintf(stderr,
+            "FAIL: One-pole not between seeded and raw target at bin %d "
+            "(%f -> %f, target %f)\n",
+            probe, gain_tonal[probe], gain_second[probe], target[probe]);
     exit(1);
   }
 


### PR DESCRIPTION
Closes #164

## Context

The per-frame denoiser gain is assembled from several decision mechanisms (Wiener/Berouti suppression, tonal handling, psychoacoustic masking veto, transient relief, smoothers). Currently several of these are applied as serial mutators of shared state (alpha, magnitude, gain fields), which creates order-dependence and cross-branch carving: e.g. the tonal notch used to be carved into the field the gain smoothers then smeared.

Generic principle applied here: suppression decisions combine with **min**, preservation decisions with **max**; each path computes its own gain from shared estimator outputs and nothing mutates another branch's input.

## Work items

1. **Tonal dual-path decoupling** (toggle `TONAL_DUAL_PATH`): split the learned noise profile into broadband + tonal residual, run the tonal notch as a parallel gain path with its own time constants, combine as `min(broadband, tonal)`. A/B measured on the synthetic hum bed (MNI 1.2965→1.1936, hum rejection −19.9→−26.3 dB) and real fixtures (no regression; effect concentrates on strongly tonal noise).
2. **Masking veto parallelization experiment** (measured, then reverted): a relaxed-alpha "preservation" branch combined as `max` was a numerical no-op in the dual-path layout; allowing it to override the tonal notch let a masked hum survive (−26.3→−5.3 dB). Veto stays serial-by-design.
3. **Transient relief rearrangement** (toggle `TRANSIENT_RELIEF_PARALLEL`): the band alpha relief (alpha lerp toward `ALPHA_MIN` pre-gain) became a parallel gain-domain blend toward the plain Wiener curve. Equal at full/no protection, softer at partial band weights; measured worst-case payload delta −38.6 dBFS at transient edges on the real-case bed (protection-on dumps).
4. **A/B measurement infrastructure**: regional tonal metrics (hum/halo/control) in the synthetic and real-case quality tests, measurement-only env/compile switches (`SPECBLEACH_REALWORLD_TRANSIENT`, `TEST_TRANSIENT_PROTECTION`), legacy path preserved byte-exact behind toggles.

## Acceptance

- All default-gate tests, audio regression references (unchanged), coupled build (`TONAL_DUAL_PATH=0`), ASAN sweep pass.
- Listening A/B on transient-edge dumps confirms the softer relief.
---

## Testing

- Default build + full test suite, coupled build (`TONAL_DUAL_PATH=0`), ASAN build: all pass; audio regression references unchanged.
- `SPECBLEACH_REALWORLD_FULL=1` real-case A/B and protection-on payload dumps referenced in the issue.
- Legacy behavior byte-identical behind `TONAL_DUAL_PATH=0` / `TRANSIENT_RELIEF_PARALLEL=0` / `TEST_TRANSIENT_PROTECTION`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of tonal noise, including hum and narrow-band interference.
  - Broadband noise reduction and tonal suppression now operate through coordinated processing paths.
  - Transient protection is preserved during tonal suppression to help retain short-lived audio details.
  - Added configurable tuning for tonal detection, smoothing, stabilization, and transient handling.

- **Tests**
  - Expanded quality testing for tonal noise, surrounding “halo” regions, transient protection, and spectral envelope behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->